### PR TITLE
feat: Add Qwen Coder OAuth subscription support

### DIFF
--- a/js/.changeset/add-qwen-oauth-support.md
+++ b/js/.changeset/add-qwen-oauth-support.md
@@ -2,9 +2,10 @@
 '@link-assistant/agent': minor
 ---
 
-Add Qwen Coder OAuth authentication support
+Add Qwen Coder OAuth subscription support
 
-- Add QwenPlugin and AlibabaPlugin to auth plugins
-- Support Qwen Coder OAuth (device flow) for free tier access
-- Support DashScope API Key authentication for both China and International regions
+- Add QwenPlugin and AlibabaPlugin to auth plugins with OAuth device flow
+- Support Qwen Coder subscription via OAuth (device flow) with free tier
+- Add token refresh support for automatic credential renewal
+- Add custom provider loaders for qwen-coder and alibaba in provider.ts
 - Both "Qwen Coder" and "Alibaba" menu items available in auth login

--- a/js/src/provider/provider.ts
+++ b/js/src/provider/provider.ts
@@ -322,6 +322,66 @@ export namespace Provider {
       };
     },
     /**
+     * Qwen Coder OAuth provider for Qwen subscription users
+     * Uses OAuth credentials from agent auth login (Qwen Coder Subscription)
+     *
+     * To authenticate, run: agent auth login (select Qwen Coder)
+     */
+    'qwen-coder': async (input) => {
+      const auth = await Auth.get('qwen-coder');
+      if (auth?.type === 'oauth') {
+        log.info(() => ({
+          message: 'using qwen-coder oauth credentials',
+        }));
+        const loaderFn = await AuthPlugins.getLoader('qwen-coder');
+        if (loaderFn) {
+          const result = await loaderFn(() => Auth.get('qwen-coder'), input);
+          if (result.fetch) {
+            return {
+              autoload: true,
+              options: {
+                apiKey: result.apiKey || '',
+                baseURL: result.baseURL,
+                fetch: result.fetch,
+              },
+            };
+          }
+        }
+      }
+      // Default: not auto-loaded without OAuth
+      return { autoload: false };
+    },
+    /**
+     * Alibaba OAuth provider (alias for Qwen Coder)
+     * Uses OAuth credentials from agent auth login (Alibaba / Qwen Coder Subscription)
+     *
+     * To authenticate, run: agent auth login (select Alibaba)
+     */
+    alibaba: async (input) => {
+      const auth = await Auth.get('alibaba');
+      if (auth?.type === 'oauth') {
+        log.info(() => ({
+          message: 'using alibaba oauth credentials',
+        }));
+        const loaderFn = await AuthPlugins.getLoader('alibaba');
+        if (loaderFn) {
+          const result = await loaderFn(() => Auth.get('alibaba'), input);
+          if (result.fetch) {
+            return {
+              autoload: true,
+              options: {
+                apiKey: result.apiKey || '',
+                baseURL: result.baseURL,
+                fetch: result.fetch,
+              },
+            };
+          }
+        }
+      }
+      // Default: not auto-loaded without OAuth
+      return { autoload: false };
+    },
+    /**
      * Google OAuth provider for Gemini subscription users
      * Uses OAuth credentials from agent auth login (Google AI Pro/Ultra)
      *


### PR DESCRIPTION
## Summary

Implements Qwen Coder OAuth subscription support for the agent CLI, based on the official [Qwen Code CLI](https://github.com/QwenLM/Qwen3-Coder) and [qwen-auth-opencode](https://github.com/lion-lef/qwen-auth-opencode) reference implementation.

### Authentication

Both **Qwen Coder** and **Alibaba** provider menu items support **Qwen Coder Subscription (OAuth)**:
- Uses OAuth 2.0 Device Authorization Grant (RFC 8628) with PKCE (S256)
- Compatible with chat.qwen.ai OAuth endpoints (same as official Qwen Code CLI)
- Automatic token refresh when credentials expire
- Free tier with 2,000 requests/day
- Automatic browser opening in GUI environments
- Manual code entry for headless/SSH environments

### Usage

```bash
# Interactive login (shows provider selection)
agent auth login

# Check authentication status
agent auth status

# Remove credentials
agent auth logout
```

### Implementation Details

- **OAuth Plugin** (`js/src/auth/plugins.ts`): QwenPlugin and AlibabaPlugin with device flow OAuth
- **Provider Loaders** (`js/src/provider/provider.ts`): Custom loaders for `qwen-coder` and `alibaba` providers (same pattern as Google OAuth / Gemini Subscription)
- **Token Refresh**: Automatic refresh via `refresh_token` grant type, matching official Qwen Code CLI
- **Credentials**: Stored in standard auth.json format
- **Costs**: Zeroed out for subscription users (free tier)
- **DashScope API Key**: Removed (not required per issue requirements; can be added later if users request it)

### Changes from previous version

- Removed DashScope API Key support (per reviewer feedback)
- Added token refresh support (was marked as TODO before)
- Added custom provider loaders in `provider.ts` matching the Gemini Subscription pattern
- Renamed labels from "OAuth (Free Tier)" to "Subscription (OAuth)" for consistency
- Merged latest changes from main branch

### Test plan
- [ ] Run `agent auth login` and select "Qwen Coder" → "Qwen Coder Subscription (OAuth)"
- [ ] Verify device code flow opens browser or shows manual instructions
- [ ] Run `agent auth login` and select "Alibaba" → "Qwen Coder Subscription (OAuth)"
- [ ] Verify same OAuth flow works via Alibaba menu item
- [ ] Run `agent auth status` to verify credentials are stored
- [ ] Run `agent auth logout` to verify credentials can be removed
- [ ] Verify token refresh works when access token expires

Closes #24

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)