### PR TITLE
fix: display CLI help text on stdout instead of stderr

### DIFF
--- a/experiments/test-help-stdout.sh
+++ b/experiments/test-help-stdout.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Test that help text goes to stdout (not stderr)
+# This verifies the fix for issue #77
+
+cd "$(dirname "$0")/.."
+
+echo "=== Testing: agent auth (no subcommand) ==="
+
+# Run 'agent auth' and capture stdout and stderr separately
+STDOUT_FILE=$(mktemp)
+STDERR_FILE=$(mktemp)
+
+bun run js/src/index.js auth >"$STDOUT_FILE" 2>"$STDERR_FILE"
+EXIT_CODE=$?
+
+STDOUT_SIZE=$(wc -c < "$STDOUT_FILE")
+STDERR_SIZE=$(wc -c < "$STDERR_FILE")
+
+echo "Exit code: $EXIT_CODE"
+echo "Stdout size: $STDOUT_SIZE bytes"
+echo "Stderr size: $STDERR_SIZE bytes"
+echo ""
+
+echo "--- STDOUT content ---"
+cat "$STDOUT_FILE"
+echo ""
+echo "--- STDERR content ---"
+cat "$STDERR_FILE"
+echo ""
+
+# Verify
+PASS=true
+
+if [ "$STDOUT_SIZE" -eq 0 ]; then
+  echo "FAIL: stdout is empty (help text should be on stdout)"
+  PASS=false
+else
+  echo "PASS: stdout has content ($STDOUT_SIZE bytes)"
+fi
+
+if [ "$STDERR_SIZE" -gt 0 ]; then
+  echo "FAIL: stderr has content (help text should NOT be on stderr)"
+  PASS=false
+else
+  echo "PASS: stderr is empty"
+fi
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  echo "FAIL: exit code should be 0 (help display is not an error)"
+  PASS=false
+else
+  echo "PASS: exit code is 0"
+fi
+
+# Check that stdout contains no ANSI color codes
+if grep -P '\x1b\[' "$STDOUT_FILE" >/dev/null 2>&1; then
+  echo "FAIL: stdout contains ANSI color codes (should be stripped)"
+  PASS=false
+else
+  echo "PASS: no ANSI color codes in stdout"
+fi
+
+rm -f "$STDOUT_FILE" "$STDERR_FILE"
+
+if [ "$PASS" = true ]; then
+  echo ""
+  echo "=== ALL TESTS PASSED ==="
+else
+  echo ""
+  echo "=== SOME TESTS FAILED ==="
+  exit 1
+fi

--- a/experiments/test-help-vs-error.sh
+++ b/experiments/test-help-vs-error.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Test that help (no subcommand) goes to stdout, but errors go to stderr
+# This verifies correct distinction per industry standards
+
+cd "$(dirname "$0")/.."
+
+echo "=== Test 1: agent auth (no subcommand = help, should go to stdout) ==="
+
+STDOUT_FILE=$(mktemp)
+STDERR_FILE=$(mktemp)
+
+bun run js/src/index.js auth >"$STDOUT_FILE" 2>"$STDERR_FILE"
+EXIT_CODE=$?
+
+echo "Exit code: $EXIT_CODE (expected: 0)"
+echo "Stdout: $(wc -c < "$STDOUT_FILE") bytes (expected: >0)"
+echo "Stderr: $(wc -c < "$STDERR_FILE") bytes (expected: 0)"
+
+PASS=true
+[ "$EXIT_CODE" -ne 0 ] && echo "FAIL: exit code" && PASS=false
+[ "$(wc -c < "$STDOUT_FILE")" -eq 0 ] && echo "FAIL: stdout empty" && PASS=false
+[ "$(wc -c < "$STDERR_FILE")" -gt 0 ] && echo "FAIL: stderr not empty" && PASS=false
+
+rm -f "$STDOUT_FILE" "$STDERR_FILE"
+
+echo ""
+echo "=== Test 2: agent --help (explicit help, handled by yargs) ==="
+
+STDOUT_FILE=$(mktemp)
+STDERR_FILE=$(mktemp)
+
+bun run js/src/index.js --help >"$STDOUT_FILE" 2>"$STDERR_FILE"
+EXIT_CODE=$?
+
+echo "Exit code: $EXIT_CODE (expected: 0)"
+echo "Stdout: $(wc -c < "$STDOUT_FILE") bytes (expected: >0)"
+echo "Stderr: $(wc -c < "$STDERR_FILE") bytes (expected: 0)"
+
+[ "$(wc -c < "$STDOUT_FILE")" -eq 0 ] && echo "FAIL: stdout empty" && PASS=false
+
+rm -f "$STDOUT_FILE" "$STDERR_FILE"
+
+echo ""
+echo "=== Test 3: agent mcp (no subcommand = help, should go to stdout) ==="
+
+STDOUT_FILE=$(mktemp)
+STDERR_FILE=$(mktemp)
+
+bun run js/src/index.js mcp >"$STDOUT_FILE" 2>"$STDERR_FILE"
+EXIT_CODE=$?
+
+echo "Exit code: $EXIT_CODE (expected: 0)"
+echo "Stdout: $(wc -c < "$STDOUT_FILE") bytes (expected: >0)"
+echo "Stderr: $(wc -c < "$STDERR_FILE") bytes (expected: 0)"
+
+[ "$EXIT_CODE" -ne 0 ] && echo "FAIL: exit code" && PASS=false
+[ "$(wc -c < "$STDOUT_FILE")" -eq 0 ] && echo "FAIL: stdout empty" && PASS=false
+[ "$(wc -c < "$STDERR_FILE")" -gt 0 ] && echo "FAIL: stderr not empty" && PASS=false
+
+rm -f "$STDOUT_FILE" "$STDERR_FILE"
+
+echo ""
+if [ "$PASS" = true ]; then
+  echo "=== ALL TESTS PASSED ==="
+else
+  echo "=== SOME TESTS FAILED ==="
+  exit 1
+fi

--- a/js/.changeset/fix-auth-help-stdout.md
+++ b/js/.changeset/fix-auth-help-stdout.md
@@ -1,0 +1,10 @@
+---
+'@link-assistant/agent': patch
+---
+
+fix: display CLI help text on stdout instead of stderr
+
+When running `agent auth` without a subcommand, the help text was displayed
+on stderr, causing it to appear in red in many terminals. Help text is
+informational and should go to stdout, following the industry standard
+behavior of CLI tools like git, gh, and npm.

--- a/js/src/cli/output.ts
+++ b/js/src/cli/output.ts
@@ -199,5 +199,24 @@ export function outputInput(
   writeStdout(message, compact);
 }
 
+/**
+ * Output a help/informational message to stdout
+ * Used for CLI help text display (not an error condition)
+ */
+export function outputHelp(
+  help: {
+    message: string;
+    hint?: string;
+    [key: string]: unknown;
+  },
+  compact?: boolean
+): void {
+  const message: OutputMessage = {
+    type: 'status',
+    ...help,
+  };
+  writeStdout(message, compact);
+}
+
 // Re-export for backward compatibility
 export { output as write };

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -31,9 +31,11 @@ import { createBusEventSubscription } from './cli/event-handler.js';
 import {
   outputStatus,
   outputError,
+  outputHelp,
   setCompactJson,
   outputInput,
 } from './cli/output.ts';
+import stripAnsi from 'strip-ansi';
 import { createRequire } from 'module';
 import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
@@ -899,14 +901,14 @@ async function main() {
           process.exit(1);
         }
 
-        // Handle validation errors (msg without err)
+        // Handle validation messages (msg without err) - informational, not an error
+        // Display help text on stdout (industry standard: git, gh, npm all use stdout for help)
         if (msg) {
-          outputError({
-            errorType: 'ValidationError',
+          outputHelp({
             message: msg,
-            hint: yargs.help(),
+            hint: stripAnsi(yargs.help()),
           });
-          process.exit(1);
+          process.exit(0);
         }
       })
       .help();


### PR DESCRIPTION
## Summary

Fixed the color issue with help text when calling `agent auth` without a subcommand.

### Problem
When running `agent auth` without specifying a subcommand (like `login`, `logout`, etc.), the help text was appearing in red color in terminals. This happened because:
1. The help text was being written to **stderr** via `outputError()`, and many terminals display stderr output in red
2. The ANSI color codes from yargs were included in the output
3. The exit code was 1 (error), even though displaying help is not an error condition

### Solution
- Added a new `outputHelp()` function in `js/src/cli/output.ts` that writes to **stdout** with type `'status'` (informational, not error)
- Modified the `.fail()` handler in `js/src/index.js` to use `outputHelp()` instead of `outputError()` for validation messages (no-subcommand case)
- Strip ANSI color codes from `yargs.help()` output using `stripAnsi()`
- Changed exit code from `1` to `0` since displaying help is not an error

### Audit Results

All `outputError()` / `writeStderr` / `process.stderr` usages in the codebase were audited:

| Location | Usage | Status |
|----------|-------|--------|
| `index.js` `.fail()` handler (msg case) | Help/validation text | **Fixed → stdout** |
| `index.js` `.fail()` handler (err case) | Command handler errors | Correct (stderr) |
| `index.js` uncaughtException/unhandledRejection | Fatal errors | Correct (stderr) |
| `index.js` AuthenticationError, FileNotFound | Real errors | Correct (stderr) |
| `index.js` ValidationError (--disable-stdin, etc.) | Config errors | Correct (stderr) |
| `continuous-mode.js` SessionNotFound | Real errors | Correct (stderr) |
| `session/agent.js` ToolExecutionError | Real errors | Correct (stderr) |
| `json-standard/index.ts` event output | Errors → stderr, rest → stdout | Correct |
| `cmd/export.ts` @clack/prompts | Interactive UI on stderr (pipe-friendly) | Correct (intentional) |

**Conclusion**: Only the `.fail()` handler's help text case was incorrectly using stderr. All other stderr usages are for genuine errors and are correct.

### Industry Standard Comparison

| Tool | No Subcommand | Destination |
|------|--------------|-------------|
| **git** | 2126 bytes stdout, 0 bytes stderr | STDOUT |
| **gh** (GitHub CLI) | 2442 bytes stdout, 0 bytes stderr | STDOUT |
| **npm** | 1268 bytes stdout, 0 bytes stderr | STDOUT |
| **agent auth** (after fix) | 609 bytes stdout, 0 bytes stderr | STDOUT |

### Changes
- `js/src/cli/output.ts`: Added `outputHelp()` function that writes to stdout
- `js/src/index.js`: Changed `.fail()` handler to use `outputHelp()` + `stripAnsi()` for validation messages
- `js/.changeset/fix-auth-help-stdout.md`: Changeset for patch release
- `experiments/test-help-stdout.sh`: Test script verifying stdout output
- `experiments/test-help-vs-error.sh`: Test script verifying help vs error distinction

### Testing
- ✅ `agent auth` help text goes to stdout (609 bytes), stderr empty (0 bytes)
- ✅ `agent mcp` help text goes to stdout (427 bytes), stderr empty (0 bytes)
- ✅ `agent --help` continues to work correctly
- ✅ No ANSI color codes in output
- ✅ Exit code is 0 (informational, not error)
- ✅ All existing unit tests pass (19 tests)
- ✅ ESLint passes
- ✅ Prettier formatting check passes
- ✅ File size check passes

Fixes #77