### PR TITLE
fix: use compaction model for summarization to prevent rate-limit amplification (#223)

### DIFF
--- a/docs/case-studies/issue-223/README.md
+++ b/docs/case-studies/issue-223/README.md
@@ -2,12 +2,14 @@
 
 ## Summary
 
-On 2026-03-31, the `@link-assistant/agent` CLI tool failed while solving GitHub issue [bpmbpm/bpm-tensor#1](https://github.com/bpmbpm/bpm-tensor/issues/1). The agent was configured to use `minimax-m2.5-free` via the `opencode` provider, with `gpt-5-nano` as the compaction model. The execution failed after ~32 minutes due to a combination of **MiniMax free-tier rate limiting** and **upstream API connection failures**.
+On 2026-03-31, the `@link-assistant/agent` CLI tool failed while solving GitHub issue [bpmbpm/bpm-tensor#1](https://github.com/bpmbpm/bpm-tensor/issues/1). The agent was configured to use `minimax-m2.5-free` via the `opencode` provider, with `gpt-5-nano` as the compaction model (`--compaction-model`). The execution failed after ~32 minutes due to a combination of **MiniMax free-tier rate limiting** and **upstream API connection failures**.
 
 **Key question from the issue:** "Why same model was selected if not requested?"  
-**Answer:** The summarization system uses the same model as `--model` by design (since [issue #217](https://github.com/link-assistant/agent/issues/217)). This is intentional behavior, not a fallback or error. However, this design decision amplifies rate-limit pressure when using free-tier models with strict quotas.
+**Answer:** The summarization system used the same model as `--model` by design (since [issue #217](https://github.com/link-assistant/agent/issues/217)). However, `gpt-5-nano` was configured as the compaction model and was available for use. The summarization system did not try `gpt-5-nano` — it only used the main model (`minimax-m2.5-free`), doubling rate-limit pressure.
 
-## Timeline of Events
+**Was `gpt-5-nano` rate-limited?** No. The logs show zero rate limit events on `gpt-5-nano`. All 25 rate limit events occurred on `minimax-m2.5-free`. The compaction model was used only for compaction overflow checks, never for summarization.
+
+## Full Sequence of Events
 
 | Time (UTC)       | Event                                                        |
 |------------------|--------------------------------------------------------------|
@@ -16,8 +18,8 @@ On 2026-03-31, the `@link-assistant/agent` CLI tool failed while solving GitHub 
 | 06:41:22 - 06:41:45 | Fork created, branch `issue-1-ae4e40cf019b`, PR #2 created |
 | 06:41:51         | Agent session begins, compaction model set to `gpt-5-nano`   |
 | 06:41:52         | **First rate limit (429)** on main model call. `retry-after: 62288s` (~17.3h) |
-| 06:41:52         | Summarization model selected: `minimax-m2.5-free` (same as `--model`) |
-| 06:41:52 - 06:42:38 | **16 rate limit events** on main model, all attempt 1. Despite this, 15 successful step-finish events occur (model responses with tool calls). The agent reads the issue, explores the repo, creates a todo list. |
+| 06:41:52         | Summarization model selected: `minimax-m2.5-free` (same as `--model`) — `gpt-5-nano` NOT tried |
+| 06:41:52 - 06:42:38 | **16 rate limit events** on `minimax-m2.5-free`, all attempt 1. Despite this, 15 successful step-finish events occur (model responses with tool calls). The agent reads the issue, explores the repo, creates a todo list. |
 | 06:42:38 - 06:43:45 | Rate limits continue. Agent makes partial progress. |
 | 06:45:50 - 07:04:48 | **8 Cloudflare 524 timeout errors** from `api.minimax.io`. Exponential backoff retries. No useful work done. |
 | 06:50:24         | First "socket connection closed unexpectedly" error          |
@@ -27,20 +29,27 @@ On 2026-03-31, the `@link-assistant/agent` CLI tool failed while solving GitHub 
 | 07:13:55         | Agent reported error, exit code 0, `errorDetectedInOutput: true` |
 
 **Total duration:** ~32 minutes (1,923 seconds)  
-**Total rate limit events:** 25  
+**Total rate limit events:** 25 (all on `minimax-m2.5-free`, zero on `gpt-5-nano`)  
 **Total successful model steps:** ~25  
 **Work accomplished:** Read issue, explored repo, created plan — but **no code was written or committed**
 
 ## Root Cause Analysis
 
-### Root Cause 1: MiniMax Free-Tier Daily Quota Exhaustion
+### Root Cause 1: Summarization Used Main Model Instead of Compaction Model
 
-The `minimax-m2.5-free` model is provided via MiniMax's free tier through the `opencode.ai` proxy. The free tier has a daily quota of **1,000 requests/day** with **100 RPM** ([MiniMax Rate Limits](https://platform.minimax.io/docs/guides/rate-limits)). The `retry-after` header values (~62,288 seconds = ~17.3 hours) indicate a **daily quota reset**, not a per-minute rate limit.
+The summarization system used the same model as `--model` (`minimax-m2.5-free`) instead of the available compaction model (`gpt-5-nano`). This doubled the request rate on the rate-limited free-tier model.
 
-The agent hit this quota almost immediately because:
-- The main model (`minimax-m2.5-free`) consumes requests for each step
-- The **summarization model also uses `minimax-m2.5-free`** (same model by design), doubling the request rate
-- The **compaction model (`gpt-5-nano`)** uses OpenAI's API but doesn't contribute to MiniMax rate limits
+**Evidence from logs:**
+```
+"hint": "Using same model as --model (not a small model)"    # Every summarization call
+"compactionModelID": "gpt-5-nano"                             # Available but unused for summarization
+```
+
+The compaction model (`gpt-5-nano`) was configured and loaded by the system for overflow checks, but the summarization code path did not have access to it — it only knew about the assistant message's `providerID` and `modelID`.
+
+### Root Cause 2: MiniMax Free-Tier Daily Quota Exhaustion
+
+The `minimax-m2.5-free` model has a daily quota of **1,000 requests/day** with **100 RPM** ([MiniMax Rate Limits](https://platform.minimax.io/docs/guides/rate-limits)). The `retry-after` header values (~62,288 seconds = ~17.3 hours) indicate a **daily quota reset**, not a per-minute rate limit.
 
 **Evidence:**
 ```
@@ -49,121 +58,72 @@ The agent hit this quota almost immediately because:
 "retryAfterMs": 62175000    # 2 minutes later, ~17.27h (countdown consistent)
 ```
 
-The decreasing `retryAfterMs` values confirm a fixed daily quota reset time.
+The decreasing values confirm a fixed daily quota reset time.
 
-### Root Cause 2: Summarization Uses Same Model (By Design)
+### Root Cause 3: Upstream API Instability (Cloudflare 524)
 
-In `js/src/session/summary.ts:97-105`, the summarization system was changed in [issue #217](https://github.com/link-assistant/agent/issues/217) to use the same model as `--model` instead of a cheaper small model:
+After the initial rate limit storm, the agent began receiving **Cloudflare 524 "A timeout occurred"** errors from `api.minimax.io`. The 8 retry attempts with exponential backoff (06:45:50 - 07:04:48) consumed ~19 minutes with zero useful work.
+
+### Root Cause 4: Socket Connection Closure
+
+The final failure was `"The socket connection was closed unexpectedly"`. This is a known issue with Bun's fetch() implementation (see [oven-sh/bun#14439](https://github.com/oven-sh/bun/issues/14439)), likely triggered by the MiniMax API dropping the connection after sustained rate limiting.
+
+## Fix Applied
+
+### Summarization Uses Compaction Model First
+
+Changed `session/summary.ts` to use the compaction model (e.g., `gpt-5-nano` set via `--compaction-model`) for summarization tasks instead of the main model. The fallback chain is:
+
+1. **Try compaction model** (`--compaction-model`, e.g. `gpt-5-nano`) — if configured and not `useSameModel`
+2. **Fall back to main model** — if compaction model is not configured or unavailable
+3. **Wait and retry** — if both are rate-limited, the existing retry mechanism will wait for limits to reset (respecting `AGENT_RETRY_TIMEOUT` of 7 days)
+
+This ensures:
+- Summarization does not consume the main model's rate-limit quota
+- The agent does not stop when rate-limited — it waits for limits to reset
+- The full `retry-after` value from the server is respected (no artificial capping)
+
+### Key Code Change
 
 ```typescript
-// Use the same model as the main session (--model) instead of a small model
-// This ensures consistent behavior and uses the model the user explicitly requested
-log.info(() => ({
-  message: 'loading model for summarization',
-  providerID: assistantMsg.providerID,
-  modelID: assistantMsg.modelID,
-  hint: 'Using same model as --model (not a small model)',
-}));
+// summary.ts — before (issue #217)
+const model = await Provider.getModel(
+  assistantMsg.providerID,
+  assistantMsg.modelID  // same as --model, doubles rate-limit pressure
+);
+
+// summary.ts — after (issue #223)
+const compactionModel = userMsg.compactionModel;
+let model = null;
+if (compactionModel && !compactionModel.useSameModel) {
+  model = await Provider.getModel(
+    compactionModel.providerID,
+    compactionModel.modelID  // e.g. gpt-5-nano — different rate-limit pool
+  );
+}
+if (!model) {
+  model = await Provider.getModel(
+    assistantMsg.providerID,
+    assistantMsg.modelID  // fallback to main model
+  );
+}
 ```
-
-This creates **double pressure** on rate-limited free-tier models: every step generates both a main model call AND a summarization model call to the same endpoint.
-
-### Root Cause 3: Retry Mechanism Accepts 17-Hour Delays
-
-The `retry-fetch.ts` wrapper has a `RETRY_TIMEOUT` of **168 hours (7 days)**. Since the 17-hour retry-after (62,288s) is less than 168 hours, the system **accepts this delay** and attempts to sleep for ~18 hours:
-
-```
-"delayMs": 64614691        # ~17.95 hours (retry-after + jitter)
-"remainingTimeoutMs": 604799654   # ~168 hours remaining
-```
-
-However, the system doesn't actually sleep for 17 hours — it appears the rate limit retry runs in the background while the main prompt loop continues making new requests (which also get rate-limited). This creates a cascade of rate-limit-retry-rate-limit cycles.
-
-### Root Cause 4: Upstream API Instability (Cloudflare 524)
-
-After the initial rate limit storm, the agent began receiving **Cloudflare 524 "A timeout occurred"** errors from `api.minimax.io`. This indicates the upstream MiniMax API server was:
-- Timing out on processing requests (origin server didn't respond within Cloudflare's timeout)
-- Potentially rate-limiting at the infrastructure level (beyond API-level 429s)
-
-The 8 retry attempts with exponential backoff (06:45:50 - 07:04:48) consumed ~19 minutes with zero useful work.
-
-### Root Cause 5: Socket Connection Closure
-
-The final failure was `"The socket connection was closed unexpectedly"`. This is a known issue with Bun's fetch() implementation (see [oven-sh/bun#14439](https://github.com/oven-sh/bun/issues/14439)), but in this case it was likely triggered by the MiniMax API dropping the connection after sustained rate limiting.
 
 ## Impact
 
 1. **No useful output:** Despite running for 32 minutes, no code was written or committed to PR #2
 2. **Wasted compute resources:** 25 successful model steps were completed but led to no tangible result
-3. **Poor user experience:** The failure log is 30,273 lines long, making it difficult to diagnose
-4. **Silent degradation:** The system appeared to make progress (tool calls were executing) but was cycling between rate limits and partial responses
-
-## Proposed Solutions
-
-### Solution 1: Use Different Model for Summarization When Rate-Limited (Recommended)
-
-**Problem:** Summarization uses the same rate-limited model, doubling API pressure.
-
-**Fix:** Add a fallback in `session/summary.ts` that detects when the main model is rate-limited and falls back to a different model for summarization (e.g., `gpt-5-nano` which is already configured as the compaction model, or use `Provider.getSmallModel()` which exists in `provider.ts:1709-1761`).
-
-```typescript
-// Proposed change in summary.ts
-const model = await Provider.getModel(
-  assistantMsg.providerID,
-  assistantMsg.modelID
-).catch(() => null);
-
-// If main model fails or is rate-limited, fall back to small model
-if (!model) {
-  const smallModel = await Provider.getSmallModel(assistantMsg.providerID);
-  // use smallModel for summarization
-}
-```
-
-**Existing component:** `Provider.getSmallModel()` in `js/src/provider/provider.ts:1709-1761` already has a priority list of cheap models per provider.
-
-### Solution 2: Add Maximum Retry-After Threshold for Free-Tier Models
-
-**Problem:** The system accepts 17-hour retry-after values because the global timeout is 168 hours.
-
-**Fix:** Add a configurable `AGENT_MAX_RETRY_AFTER` threshold (e.g., 30 minutes default). If `retry-after` exceeds this, fail fast or switch to a fallback model instead of sleeping for hours.
-
-**Existing component:** The `retry-fetch.ts` already has the `maxRetryTimeout` check (line 116). A new `maxRetryAfter` parameter would cap individual retry-after values independently of the global timeout.
-
-### Solution 3: Implement Model Fallback Chain
-
-**Problem:** When a model is rate-limited, there's no automatic fallback to alternative models.
-
-**Fix:** Implement a fallback model chain similar to [pydantic-ai's FallbackModel](https://github.com/pydantic/pydantic-ai/issues/3267) or [Vercel AI SDK Discussion #3387](https://github.com/vercel/ai/discussions/3387). When the primary model returns 429 with a long retry-after, automatically switch to an alternative model.
-
-**Related libraries:**
-- **LiteLLM:** Provides model fallback and load balancing across providers
-- **OpenRouter:** Supports automatic model fallback via their API
-- **Vercel AI SDK FallbackModel:** Pattern for fallback model chains (not yet fully implemented)
-
-### Solution 4: Rate-Limit-Aware Request Budgeting
-
-**Problem:** The system doesn't track how many requests remain in the quota.
-
-**Fix:** Parse rate limit headers (`x-ratelimit-remaining`, `x-ratelimit-reset`) from successful responses to proactively detect when quota is running low. When remaining requests are below a threshold, switch to a more economical mode (fewer summarization calls, batched compaction).
-
-### Solution 5: Separate Summarization Rate-Limit Tracking
-
-**Problem:** Summarization and main model calls share the same rate-limited endpoint but aren't coordinated.
-
-**Fix:** Add a shared rate-limit tracker that prevents summarization calls when the main model is already rate-limited. This would be a lightweight in-memory counter that both the main prompt loop and summarization system check before making API calls.
+3. **Silent degradation:** The system appeared to make progress (tool calls were executing) but was cycling between rate limits and partial responses
 
 ## Key Files
 
 | File | Relevance |
 |------|-----------|
-| `js/src/session/summary.ts:97-117` | Summarization model selection (uses same model as `--model`) |
+| `js/src/session/summary.ts` | Summarization model selection — now uses compaction model first |
 | `js/src/provider/retry-fetch.ts` | Rate limit retry logic with 168h global timeout |
 | `js/src/session/prompt.ts:546-554` | Compaction model selection (separate from summarization) |
 | `js/src/session/compaction.ts:43-48` | CompactionModelConfig interface |
-| `js/src/provider/provider.ts:1709-1761` | `getSmallModel()` - existing cheap model fallback (unused for summarization) |
-| `js/src/cli/model-config.js:172-232` | `parseCompactionModelConfig()` CLI parsing |
-| `js/src/session/retry.ts` | Session-level retry state tracking |
+| `js/src/provider/provider.ts:1709-1761` | `getSmallModel()` - existing cheap model fallback |
 
 ## References
 
@@ -173,7 +133,4 @@ if (!model) {
 - **Summarization model change:** [link-assistant/agent#217](https://github.com/link-assistant/agent/issues/217)
 - **Rate limit retry improvements:** [link-assistant/agent#167](https://github.com/link-assistant/agent/issues/167), [#183](https://github.com/link-assistant/agent/issues/183)
 - **Bun socket timeout issue:** [oven-sh/bun#14439](https://github.com/oven-sh/bun/issues/14439)
-- **Vercel AI SDK rate limit headers:** [vercel/ai#7247](https://github.com/vercel/ai/issues/7247)
-- **Vercel AI SDK model fallback discussion:** [vercel/ai#3387](https://github.com/vercel/ai/discussions/3387)
 - **MiniMax rate limits docs:** [platform.minimax.io/docs/guides/rate-limits](https://platform.minimax.io/docs/guides/rate-limits)
-- **OpenCode Go pricing/limits:** [opencode.ai/go](https://opencode.ai/go)

--- a/js/.changeset/fix-rate-limit-amplification.md
+++ b/js/.changeset/fix-rate-limit-amplification.md
@@ -2,4 +2,4 @@
 '@link-assistant/agent': patch
 ---
 
-fix: prevent rate-limit amplification for free-tier models by using different model for summarization and capping retry-after at MAX_RETRY_DELAY (#223)
+fix: use compaction model (--compaction-model) for summarization to avoid doubling rate-limit pressure on free-tier main models (#223)

--- a/js/src/provider/provider.ts
+++ b/js/src/provider/provider.ts
@@ -1706,30 +1706,17 @@ export namespace Provider {
    *
    * @see https://github.com/link-assistant/agent/issues/179
    */
-  export async function getSmallModel(
-    providerID: string,
-    excludeModelID?: string
-  ) {
+  export async function getSmallModel(providerID: string) {
     const cfg = await Config.get();
 
     if (cfg.small_model) {
       const parsed = parseModel(cfg.small_model);
-      // Skip configured small_model if it matches the excluded model
-      if (excludeModelID && parsed.modelID === excludeModelID) {
-        log.info(() => ({
-          message:
-            'configured small_model matches excluded model, falling back to priority list',
-          modelID: parsed.modelID,
-          excludeModelID,
-        }));
-      } else {
-        log.info(() => ({
-          message: 'using configured small_model for auxiliary task',
-          modelID: parsed.modelID,
-          providerID: parsed.providerID,
-        }));
-        return getModel(parsed.providerID, parsed.modelID);
-      }
+      log.info(() => ({
+        message: 'using configured small_model for auxiliary task',
+        modelID: parsed.modelID,
+        providerID: parsed.providerID,
+      }));
+      return getModel(parsed.providerID, parsed.modelID);
     }
 
     const provider = await state().then((state) => state.providers[providerID]);
@@ -1759,14 +1746,8 @@ export namespace Provider {
       ];
     }
     for (const item of priority) {
-      // Skip candidates that match the excluded model to avoid
-      // using the same rate-limited model for auxiliary tasks
-      // See: https://github.com/link-assistant/agent/issues/223
-      if (excludeModelID && item === excludeModelID) continue;
       for (const model of Object.keys(provider.info.models)) {
         if (model.includes(item)) {
-          // Skip if this exact model matches the excluded model
-          if (excludeModelID && model === excludeModelID) continue;
           log.info(() => ({
             message: 'selected small model for auxiliary task',
             modelID: model,

--- a/js/src/provider/retry-fetch.ts
+++ b/js/src/provider/retry-fetch.ts
@@ -125,29 +125,11 @@ export namespace RetryFetch {
         return null;
       }
 
-      // Cap retry-after at maxBackoffDelay to prevent extremely long waits
-      // (e.g., free-tier daily quota resets returning 17-hour retry-after values).
-      // The system will retry sooner and may still get 429s, but this prevents
-      // a single retry attempt from blocking for hours.
-      // See: https://github.com/link-assistant/agent/issues/223
-      const cappedRetryAfterMs = Math.min(retryAfterMs, maxBackoffDelay);
-      if (cappedRetryAfterMs < retryAfterMs) {
-        log.info(() => ({
-          message: 'capping retry-after at max retry delay',
-          originalRetryAfterMs: retryAfterMs,
-          originalRetryAfterHours: (retryAfterMs / 1000 / 3600).toFixed(2),
-          cappedRetryAfterMs,
-          cappedRetryAfterMinutes: (cappedRetryAfterMs / 1000 / 60).toFixed(2),
-          maxBackoffDelayMs: maxBackoffDelay,
-        }));
-      }
-
-      // Use capped retry-after time, but ensure minimum interval
-      const delay = Math.max(cappedRetryAfterMs, minInterval);
+      // Use exact retry-after time, but ensure minimum interval
+      const delay = Math.max(retryAfterMs, minInterval);
       log.info(() => ({
         message: 'using retry-after value',
         retryAfterMs,
-        cappedRetryAfterMs,
         delayMs: delay,
         minIntervalMs: minInterval,
       }));

--- a/js/src/session/summary.ts
+++ b/js/src/session/summary.ts
@@ -94,32 +94,38 @@ export namespace SessionSummary {
     const assistantMsg = messages.find((m) => m.info.role === 'assistant')!
       .info as MessageV2.Assistant;
 
-    // Try to use a different (smaller) model for summarization to avoid
-    // doubling rate-limit pressure on the main model, especially for
-    // free-tier models with strict daily quotas.
-    // Falls back to the main model if no alternative is available.
-    // See: https://github.com/link-assistant/agent/issues/217
+    // Use the compaction model (--compaction-model, e.g. gpt-5-nano) for summarization
+    // to avoid doubling rate-limit pressure on the main model.
+    // If the compaction model is unavailable, fall back to the main model.
     // See: https://github.com/link-assistant/agent/issues/223
-    let model = await Provider.getSmallModel(
-      assistantMsg.providerID,
-      assistantMsg.modelID
-    ).catch(() => null);
+    const compactionModel = userMsg.compactionModel;
+    let model: Awaited<ReturnType<typeof Provider.getModel>> | null = null;
 
-    if (model) {
-      log.info(() => ({
-        message: 'loading model for summarization',
-        providerID: model!.providerID,
-        modelID: model!.modelID,
-        hint: 'Using different model to reduce rate-limit pressure on main model',
-        mainModelID: assistantMsg.modelID,
-      }));
-    } else {
-      // Fall back to the main model if no alternative is available
+    if (compactionModel && !compactionModel.useSameModel) {
+      model = await Provider.getModel(
+        compactionModel.providerID,
+        compactionModel.modelID
+      ).catch(() => null);
+      if (model) {
+        log.info(() => ({
+          message: 'loading model for summarization',
+          providerID: model!.providerID,
+          modelID: model!.modelID,
+          hint: 'Using compaction model to reduce rate-limit pressure on main model',
+          mainModelID: assistantMsg.modelID,
+        }));
+      }
+    }
+
+    if (!model) {
+      // Fall back to the main model if compaction model is not configured or unavailable
       log.info(() => ({
         message: 'loading model for summarization',
         providerID: assistantMsg.providerID,
         modelID: assistantMsg.modelID,
-        hint: 'Using same model as --model (no alternative available)',
+        hint: compactionModel
+          ? 'Compaction model unavailable, falling back to main model'
+          : 'Using same model as --model (no compaction model configured)',
       }));
       model = await Provider.getModel(
         assistantMsg.providerID,

--- a/js/tests/retry-fetch.test.ts
+++ b/js/tests/retry-fetch.test.ts
@@ -416,59 +416,49 @@ describe('Isolated signal for rate limit waits (issue #183)', () => {
 });
 
 /**
- * Tests for retry-after capping at MAX_RETRY_DELAY (issue #223)
+ * Tests for long retry-after behavior (issue #223)
  *
- * When free-tier models return extremely long retry-after values (e.g., 17 hours
- * for daily quota resets), the system should cap the wait at MAX_RETRY_DELAY
- * instead of sleeping for hours.
+ * When free-tier models return long retry-after values (e.g., 17 hours for
+ * daily quota resets), the system should respect those values and wait.
+ * The agent should not stop — it should wait for the limit to reset and retry.
  *
  * @see https://github.com/link-assistant/agent/issues/223
  */
-describe('Retry-after capping at MAX_RETRY_DELAY (issue #223)', () => {
-  test('caps retry-after at MAX_RETRY_DELAY when header exceeds it', async () => {
+describe('Long retry-after values are respected (issue #223)', () => {
+  test('accepts long retry-after and waits (does not cap)', async () => {
     const originalRetryTimeout = process.env['AGENT_RETRY_TIMEOUT'];
     const originalMinInterval = process.env['AGENT_MIN_RETRY_INTERVAL'];
-    const originalMaxDelay = process.env['AGENT_MAX_RETRY_DELAY'];
 
-    // Set config: long global timeout, short max delay, no min interval
-    process.env['AGENT_RETRY_TIMEOUT'] = '604800'; // 7 days
+    // Set a short global timeout so the system gives up quickly
+    // but long enough that a short retry-after (1s) would succeed
+    process.env['AGENT_RETRY_TIMEOUT'] = '2'; // 2 seconds
     process.env['AGENT_MIN_RETRY_INTERVAL'] = '0';
-    process.env['AGENT_MAX_RETRY_DELAY'] = '1'; // 1 second max delay (1000ms)
 
     try {
-      let callCount = 0;
-      const startTime = Date.now();
-      const mockFetch = mock(() => {
-        callCount++;
-        if (callCount === 1) {
-          // Server says wait 17 hours (like MiniMax free tier daily quota reset)
-          return Promise.resolve(
-            new Response('rate limited', {
-              status: 429,
-              headers: {
-                'retry-after': '62288', // ~17.3 hours
-              },
-            })
-          );
-        }
-        return Promise.resolve(new Response('success', { status: 200 }));
-      });
+      const mockFetch = mock(() =>
+        Promise.resolve(
+          new Response('rate limited', {
+            status: 429,
+            headers: {
+              // Server says wait 17 hours — exceeds our 2s global timeout
+              // Without capping, this should be rejected as "exceeds remaining timeout"
+              'retry-after': '62288',
+            },
+          })
+        )
+      );
 
       const retryFetch = RetryFetch.create({
         baseFetch: mockFetch as unknown as typeof fetch,
       });
 
       const result = await retryFetch('https://example.com');
-      const elapsed = Date.now() - startTime;
 
-      // Should succeed after retry
-      expect(mockFetch).toHaveBeenCalledTimes(2);
-      expect(result.status).toBe(200);
-
-      // The actual wait should be close to MAX_RETRY_DELAY (1s + jitter),
-      // NOT the 17-hour retry-after value
-      // Allow up to 3 seconds for jitter and test overhead
-      expect(elapsed).toBeLessThan(3000);
+      // Should return 429 because retry-after (17h) exceeds global timeout (2s)
+      // This proves the system does NOT cap the value — it uses the full retry-after
+      // and correctly determines it won't fit within the global timeout
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe(429);
     } finally {
       if (originalRetryTimeout !== undefined) {
         process.env['AGENT_RETRY_TIMEOUT'] = originalRetryTimeout;
@@ -480,10 +470,48 @@ describe('Retry-after capping at MAX_RETRY_DELAY (issue #223)', () => {
       } else {
         delete process.env['AGENT_MIN_RETRY_INTERVAL'];
       }
-      if (originalMaxDelay !== undefined) {
-        process.env['AGENT_MAX_RETRY_DELAY'] = originalMaxDelay;
+    }
+  });
+
+  test('returns 429 when retry-after exceeds global timeout', async () => {
+    const originalRetryTimeout = process.env['AGENT_RETRY_TIMEOUT'];
+    const originalMinInterval = process.env['AGENT_MIN_RETRY_INTERVAL'];
+
+    // Set global timeout shorter than the retry-after
+    process.env['AGENT_RETRY_TIMEOUT'] = '3600'; // 1 hour
+    process.env['AGENT_MIN_RETRY_INTERVAL'] = '0';
+
+    try {
+      const mockFetch = mock(() =>
+        Promise.resolve(
+          new Response('rate limited', {
+            status: 429,
+            headers: {
+              'retry-after': '62288', // ~17.3 hours (exceeds 1 hour timeout)
+            },
+          })
+        )
+      );
+
+      const retryFetch = RetryFetch.create({
+        baseFetch: mockFetch as unknown as typeof fetch,
+      });
+
+      const result = await retryFetch('https://example.com');
+
+      // Should return 429 immediately because retry-after exceeds global timeout
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(result.status).toBe(429);
+    } finally {
+      if (originalRetryTimeout !== undefined) {
+        process.env['AGENT_RETRY_TIMEOUT'] = originalRetryTimeout;
       } else {
-        delete process.env['AGENT_MAX_RETRY_DELAY'];
+        delete process.env['AGENT_RETRY_TIMEOUT'];
+      }
+      if (originalMinInterval !== undefined) {
+        process.env['AGENT_MIN_RETRY_INTERVAL'] = originalMinInterval;
+      } else {
+        delete process.env['AGENT_MIN_RETRY_INTERVAL'];
       }
     }
   });


### PR DESCRIPTION
## Summary

Use the compaction model (`--compaction-model`, e.g. `gpt-5-nano`) for summarization instead of the main model, preventing double rate-limit pressure on free-tier models.

### Root Cause

When using `minimax-m2.5-free` as the main model with `gpt-5-nano` as the compaction model:
- **Summarization used the same model as `--model`** (`minimax-m2.5-free`), doubling API request rate
- **`gpt-5-nano` was available but never tried** for summarization — it was only used for compaction
- All 25 rate limit events were on `minimax-m2.5-free`; zero on `gpt-5-nano`

### Approach (per reviewer feedback)

1. **First try `gpt-5-nano`** (the `--compaction-model`) for summarization
2. **If unavailable, fall back to the main model** (`minimax-m2.5-free`)
3. **If rate-limited, wait for limits to reset and retry** — the agent should not stop
4. **Do not reduce timeouts** — respect the server's `retry-after` values

### Changes

- **`js/src/session/summary.ts`**: Summarization now uses the compaction model (from `userMsg.compactionModel`) first, falling back to the main model only if no compaction model is configured
- **`js/src/provider/retry-fetch.ts`**: Reverted retry-after capping — long `retry-after` values (e.g., 17 hours for daily quota reset) are respected as-is
- **`js/src/provider/provider.ts`**: Reverted `excludeModelID` parameter from `getSmallModel()` — no longer needed since summarization uses the compaction model directly
- **`js/tests/retry-fetch.test.ts`**: Updated tests to verify long retry-after values are respected (not capped)
- **`docs/case-studies/issue-223/`**: Updated case study with corrected analysis and full event sequence

### Case Study

Full analysis in [`docs/case-studies/issue-223/README.md`](https://github.com/link-assistant/agent/blob/issue-223-ee2ccec2ad75/docs/case-studies/issue-223/README.md)

**Key evidence from logs:**
```
"hint": "Using same model as --model (not a small model)"    # Every summarization call
"compactionModelID": "gpt-5-nano"                             # Available but unused for summarization
Rate limit events on minimax-m2.5-free: 25
Rate limit events on gpt-5-nano: 0
```

## Test Plan

- [x] Updated test: long retry-after values are respected (not capped)
- [x] Existing retry-fetch tests pass (20/20)
- [x] Full unit test suite: 335 pass, 4 todo (138 pre-existing failures from test env, same as main branch)
- [x] Prettier formatting verified
- [ ] Integration test with free-tier model to verify reduced rate limiting

## References

- **Issue:** #223
- **MiniMax rate limits:** [platform.minimax.io/docs/guides/rate-limits](https://platform.minimax.io/docs/guides/rate-limits)
- **Bun socket timeout:** [oven-sh/bun#14439](https://github.com/oven-sh/bun/issues/14439)
- **Related agent issues:** #167, #183, #217

Fixes #223