### PR TITLE
feat: add `--temperature` CLI option + sync all Rust CLI options with JS

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-10T19:38:43.616Z for PR creation at branch issue-241-d06e060818b2 for issue https://github.com/link-assistant/agent/issues/241

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-10T19:38:43.616Z for PR creation at branch issue-241-d06e060818b2 for issue https://github.com/link-assistant/agent/issues/241

--- a/docs/case-studies/issue-241/README.md
+++ b/docs/case-studies/issue-241/README.md
@@ -1,0 +1,143 @@
+# Case Study: Add `--temperature` CLI Option
+
+**Issue:** [#241](https://github.com/link-assistant/agent/issues/241)
+**PR:** [#244](https://github.com/link-assistant/agent/pull/244)
+
+## Problem Statement
+
+The agent CLI lacked a user-facing `--temperature` option. Temperature was determined entirely by internal logic:
+1. Model-level: `ProviderTransform.temperature()` returned hard-coded values per model family (e.g., Qwen: 0.55, Claude: `undefined`, Gemini 3 Pro: 1.0, others: 0).
+2. Agent-level: Agent configuration files (`.link-assistant-agent/opencode.jsonc`) could override temperature per agent.
+3. Model metadata gate: Temperature was only applied if `model.info.temperature === true`.
+
+Users had no way to override temperature from the command line for quick experimentation or to tune outputs for specific tasks without editing configuration files.
+
+## Requirements from Issue
+
+1. **Add `--temperature` option** to the CLI.
+2. **Preserve existing behavior when not set** ("if it is not set, we don't change current behavior at all").
+3. **Collect data and produce a case study** in `./docs/case-studies/issue-241/`.
+
+## Background: Temperature in LLM APIs
+
+Temperature controls the randomness of token selection by scaling logit values before the softmax function converts them into probabilities. It is the single most important LLM sampling parameter.
+
+### Temperature Ranges by Provider
+
+| Provider | Model Examples | Valid Range |
+| -------- | -------------- | ----------- |
+| OpenAI | gpt-4o, o3 | 0.0 -- 2.0 |
+| Anthropic | claude-4-opus | 0.0 -- 1.0 |
+| Google | gemini-2.5-pro | 0.0 -- 2.0 |
+
+### Recommended Values by Use Case
+
+| Use Case | Temperature | Rationale |
+| -------- | ----------- | --------- |
+| Code generation, data extraction | 0.0 -- 0.2 | Deterministic, consistent |
+| Balanced general tasks | 0.5 -- 0.7 | Good mix of coherence and variety |
+| Creative writing, brainstorming | 0.8 -- 1.2 | Higher novelty and diversity |
+
+### References
+
+- [LLM Temperature Settings Guide (Tetrate)](https://tetrate.io/learn/ai/llm-temperature-guide)
+- [What is LLM Temperature? (IBM)](https://www.ibm.com/think/topics/llm-temperature)
+- [LLM Sampling Parameters Explained](https://letsdatascience.com/blog/llm-sampling-temperature-top-k-top-p-and-min-p-explained)
+- [How to Choose the Right LLM Temperature (Promptfoo)](https://www.promptfoo.dev/docs/guides/evaluate-llm-temperature/)
+
+## Existing Temperature Resolution (Before This Change)
+
+```
+model.info.temperature == true?
+  ├─ YES → agent.temperature ?? ProviderTransform.temperature(providerID, modelID)
+  └─ NO  → undefined (provider default)
+```
+
+### Per-Model Defaults in `ProviderTransform.temperature()`
+
+| Model Family | Default Temperature |
+| ------------ | ------------------- |
+| Qwen* | 0.55 |
+| Claude* | `undefined` (provider default) |
+| Gemini 3 Pro | 1.0 |
+| All others | 0 (deterministic) |
+
+## Solution
+
+### Architecture: CLI Temperature as Highest Priority Override
+
+The new resolution chain is:
+
+```
+CLI --temperature is set?
+  ├─ YES → use CLI value (bypasses model.info.temperature gate)
+  └─ NO  → existing behavior:
+           model.info.temperature == true?
+             ├─ YES → agent.temperature ?? ProviderTransform.temperature(...)
+             └─ NO  → undefined (provider default)
+```
+
+**Key design decision:** When `--temperature` is explicitly provided via CLI, it bypasses the `model.info.temperature` gate. This is intentional — the user is making an explicit override and should be able to set temperature even for models that don't normally expose it.
+
+### Changes Made
+
+| File | Change |
+| ---- | ------ |
+| `js/src/cli/run-options.js` | Added `--temperature` option (type: number, no default) |
+| `js/src/session/prompt.ts` | Added `temperature` to `PromptInput` schema; CLI temperature takes priority in resolution |
+| `js/src/session/message-v2.ts` | Added optional `temperature` field to `User` message schema |
+| `js/src/index.js` | Passes `argv.temperature` through `runServerMode`, `runDirectMode`, continuous mode variants |
+| `js/src/cli/continuous-mode.js` | Passes `temperature` through `runContinuousServerMode`, `runContinuousDirectMode` |
+| `rust/src/cli.rs` | Added `--temperature` as `Option<f64>` to `Args` struct |
+
+### Data Flow
+
+```
+CLI: --temperature 0.7
+  → argv.temperature = 0.7
+  → runServerMode/runDirectMode(... temperature)
+  → SessionPrompt.prompt({ ..., temperature: 0.7 })
+  → createUserMessage() stores temperature in User message
+  → loop() reads lastUser.temperature
+  → params.temperature = 0.7 (overrides all other sources)
+  → AI SDK generateText({ temperature: 0.7, ... })
+```
+
+### Test Coverage
+
+New test file: `js/tests/temperature-option.test.ts`
+
+| Test | Assertion |
+| ---- | --------- |
+| run-options.js defines temperature option | Type is `number`, no default value |
+| ProviderTransform.temperature defaults | Qwen=0.55, Claude=undefined, Gemini 3 Pro=1.0, others=0 |
+| MessageV2.User schema with temperature | Accepts and correctly parses optional temperature field |
+| SessionPrompt.PromptInput with temperature | Schema validates temperature field |
+| Rust CLI temperature field | `Option<f64>` with `#[arg(long)]` attribute |
+
+## Usage Examples
+
+```bash
+# Use default temperature (existing behavior, unchanged)
+agent -p "Write a function to sort an array"
+
+# Override temperature for more creative output
+agent --temperature 0.8 -p "Write a poem about coding"
+
+# Set temperature to 0 for deterministic output
+agent --temperature 0 -p "Extract the date from this text: ..."
+
+# Works with all other options
+agent --temperature 0.5 --model opencode/gpt-5-nano -p "Explain recursion"
+
+# Environment variable support (via lino-arguments)
+LINK_ASSISTANT_AGENT_TEMPERATURE=0.7 agent -p "Hello"
+```
+
+## Risk Assessment
+
+| Risk | Mitigation |
+| ---- | ---------- |
+| Breaking existing behavior | No default value — when unset, existing code paths are untouched |
+| Invalid temperature values | Providers validate and return errors for out-of-range values |
+| Interaction with agent config temperature | CLI explicitly overrides agent config (documented priority chain) |

--- a/js/.changeset/add-temperature-option-241.md
+++ b/js/.changeset/add-temperature-option-241.md
@@ -1,0 +1,11 @@
+---
+'@link-assistant/agent': minor
+---
+
+feat: add --temperature CLI option for model completion override (#241)
+
+- Added `--temperature` flag to JS and Rust CLI implementations
+- When set, overrides per-model and per-agent temperature defaults
+- When not set, existing behavior is unchanged
+- Temperature flows through PromptInput schema and User message to AI SDK
+- Priority chain: CLI --temperature > agent config > model defaults

--- a/js/src/cli/continuous-mode.js
+++ b/js/src/cli/continuous-mode.js
@@ -194,7 +194,8 @@ export async function runContinuousServerMode(
   systemMessage,
   appendSystemMessage,
   jsonStandard,
-  compactionModel
+  compactionModel,
+  temperature
 ) {
   // Check both CLI flag and environment variable for compact JSON mode
   const compactJson = argv['compact-json'] === true || config.compactJson;
@@ -290,6 +291,7 @@ export async function runContinuousServerMode(
             compactionModel,
             system: systemMessage,
             appendSystem: appendSystemMessage,
+            temperature,
           }),
         }
       ).catch((error) => {
@@ -446,7 +448,8 @@ export async function runContinuousDirectMode(
   systemMessage,
   appendSystemMessage,
   jsonStandard,
-  compactionModel
+  compactionModel,
+  temperature
 ) {
   // Check both CLI flag and environment variable for compact JSON mode
   const compactJson = argv['compact-json'] === true || config.compactJson;
@@ -523,6 +526,7 @@ export async function runContinuousDirectMode(
         compactionModel,
         system: systemMessage,
         appendSystem: appendSystemMessage,
+        temperature,
       }).catch((error) => {
         hasError = true;
         eventHandler.output({

--- a/js/src/cli/run-options.js
+++ b/js/src/cli/run-options.js
@@ -168,5 +168,10 @@ export function buildRunOptions(yargs) {
       description:
         'Safety margin (%) of usable context window before triggering compaction. Only applies when the compaction model has equal or smaller context than the base model. Default: 15.',
       default: DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT,
+    })
+    .option('temperature', {
+      type: 'number',
+      description:
+        'Override the temperature for model completions. When not set, the default per-model temperature is used.',
     });
 }

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -313,7 +313,8 @@ async function runAgentMode(argv, request) {
           systemMessage,
           appendSystemMessage,
           jsonStandard,
-          compactionModel
+          compactionModel,
+          argv.temperature
         );
       } else {
         // DIRECT MODE: Run everything in single process
@@ -325,7 +326,8 @@ async function runAgentMode(argv, request) {
           systemMessage,
           appendSystemMessage,
           jsonStandard,
-          compactionModel
+          compactionModel,
+          argv.temperature
         );
       }
     },
@@ -399,7 +401,8 @@ async function runContinuousAgentMode(argv) {
           systemMessage,
           appendSystemMessage,
           jsonStandard,
-          compactionModel
+          compactionModel,
+          argv.temperature
         );
       } else {
         // DIRECT MODE: Run everything in single process
@@ -410,7 +413,8 @@ async function runContinuousAgentMode(argv) {
           systemMessage,
           appendSystemMessage,
           jsonStandard,
-          compactionModel
+          compactionModel,
+          argv.temperature
         );
       }
     },
@@ -433,7 +437,8 @@ async function runServerMode(
   systemMessage,
   appendSystemMessage,
   jsonStandard,
-  compactionModel
+  compactionModel,
+  temperature
 ) {
   const compactJson = argv['compact-json'] === true;
 
@@ -502,6 +507,7 @@ async function runServerMode(
           compactionModel,
           system: systemMessage,
           appendSystem: appendSystemMessage,
+          temperature,
         }),
       }
     ).catch((error) => {
@@ -534,7 +540,8 @@ async function runDirectMode(
   systemMessage,
   appendSystemMessage,
   jsonStandard,
-  compactionModel
+  compactionModel,
+  temperature
 ) {
   const compactJson = argv['compact-json'] === true;
 
@@ -587,6 +594,7 @@ async function runDirectMode(
       compactionModel,
       system: systemMessage,
       appendSystem: appendSystemMessage,
+      temperature,
     }).catch((error) => {
       hasError = true;
       eventHandler.output({

--- a/js/src/session/message-v2.ts
+++ b/js/src/session/message-v2.ts
@@ -411,6 +411,7 @@ export namespace MessageV2 {
       .optional(),
     system: z.string().optional(),
     appendSystem: z.string().optional(),
+    temperature: z.number().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
   }).meta({
     ref: 'UserMessage',

--- a/js/src/session/prompt.ts
+++ b/js/src/session/prompt.ts
@@ -110,6 +110,7 @@ export namespace SessionPrompt {
     noReply: z.boolean().optional(),
     system: z.string().optional(),
     appendSystem: z.string().optional(),
+    temperature: z.number().optional(),
     tools: z.record(z.string(), z.boolean()).optional(),
     parts: z.array(
       z.discriminatedUnion('type', [
@@ -734,10 +735,12 @@ export namespace SessionPrompt {
       });
       const params = {
         temperature:
-          (model.info?.temperature ?? false)
-            ? (agent.temperature ??
-              ProviderTransform.temperature(model.providerID, model.modelID))
-            : undefined,
+          lastUser.temperature != null
+            ? lastUser.temperature
+            : (model.info?.temperature ?? false)
+              ? (agent.temperature ??
+                ProviderTransform.temperature(model.providerID, model.modelID))
+              : undefined,
         topP:
           agent.topP ?? ProviderTransform.topP(model.providerID, model.modelID),
         options: {
@@ -1189,6 +1192,7 @@ export namespace SessionPrompt {
       tools: input.tools,
       system: input.system,
       appendSystem: input.appendSystem,
+      temperature: input.temperature,
       agent: agent.name,
       model: await resolveModel({
         model: input.model,

--- a/js/tests/temperature-option.test.ts
+++ b/js/tests/temperature-option.test.ts
@@ -35,14 +35,10 @@ describe('--temperature CLI option (#241)', () => {
   });
 
   test('ProviderTransform.temperature returns model-specific defaults', async () => {
-    const { ProviderTransform } = await import(
-      '../src/provider/transform.ts'
-    );
+    const { ProviderTransform } = await import('../src/provider/transform.ts');
 
     // Qwen models → 0.55
-    expect(ProviderTransform.temperature('opencode', 'qwen3-coder')).toBe(
-      0.55
-    );
+    expect(ProviderTransform.temperature('opencode', 'qwen3-coder')).toBe(0.55);
 
     // Claude models → undefined (use provider default)
     expect(
@@ -50,14 +46,12 @@ describe('--temperature CLI option (#241)', () => {
     ).toBeUndefined();
 
     // Gemini 3 Pro → 1.0
-    expect(
-      ProviderTransform.temperature('google', 'gemini-3-pro')
-    ).toBe(1.0);
+    expect(ProviderTransform.temperature('google', 'gemini-3-pro')).toBe(1.0);
 
     // Other models → 0
-    expect(
-      ProviderTransform.temperature('opencode', 'minimax-m2.5-free')
-    ).toBe(0);
+    expect(ProviderTransform.temperature('opencode', 'minimax-m2.5-free')).toBe(
+      0
+    );
   });
 
   test('MessageV2.User schema accepts optional temperature field', async () => {
@@ -133,6 +127,8 @@ describe('--temperature Rust CLI option (#241)', () => {
     expect(cliSource).toContain('pub temperature: Option<f64>');
     // Verify it has the correct arg attribute (no default value)
     expect(cliSource).toContain('#[arg(long)]');
-    expect(cliSource).toContain('/// Override the temperature for model completions');
+    expect(cliSource).toContain(
+      '/// Override the temperature for model completions'
+    );
   });
 });

--- a/js/tests/temperature-option.test.ts
+++ b/js/tests/temperature-option.test.ts
@@ -1,0 +1,138 @@
+import { test, expect, describe, setDefaultTimeout } from 'bun:test';
+
+/**
+ * Tests for --temperature CLI option.
+ *
+ * Issue #241: Add --temperature option that overrides the per-model and
+ * per-agent temperature defaults. When not set, existing behavior must
+ * remain unchanged.
+ *
+ * @see https://github.com/link-assistant/agent/issues/241
+ */
+
+setDefaultTimeout(30000);
+
+describe('--temperature CLI option (#241)', () => {
+  test('run-options.js defines a temperature option of type number', async () => {
+    // Verify yargs option definition exists and is correctly typed.
+    // We import buildRunOptions and call it with a mock yargs to inspect options.
+    const { buildRunOptions } = await import('../src/cli/run-options.js');
+
+    const options: Record<string, any> = {};
+    const mockYargs = {
+      option(name: string, config: any) {
+        options[name] = config;
+        return mockYargs;
+      },
+    };
+
+    buildRunOptions(mockYargs);
+
+    expect(options['temperature']).toBeDefined();
+    expect(options['temperature'].type).toBe('number');
+    // Must NOT have a default — when unset, current behavior is preserved.
+    expect(options['temperature'].default).toBeUndefined();
+  });
+
+  test('ProviderTransform.temperature returns model-specific defaults', async () => {
+    const { ProviderTransform } = await import(
+      '../src/provider/transform.ts'
+    );
+
+    // Qwen models → 0.55
+    expect(ProviderTransform.temperature('opencode', 'qwen3-coder')).toBe(
+      0.55
+    );
+
+    // Claude models → undefined (use provider default)
+    expect(
+      ProviderTransform.temperature('anthropic', 'claude-sonnet-4')
+    ).toBeUndefined();
+
+    // Gemini 3 Pro → 1.0
+    expect(
+      ProviderTransform.temperature('google', 'gemini-3-pro')
+    ).toBe(1.0);
+
+    // Other models → 0
+    expect(
+      ProviderTransform.temperature('opencode', 'minimax-m2.5-free')
+    ).toBe(0);
+  });
+
+  test('MessageV2.User schema accepts optional temperature field', async () => {
+    const { MessageV2 } = await import('../src/session/message-v2.ts');
+
+    // Valid user message without temperature
+    const withoutTemp = MessageV2.User.safeParse({
+      id: 'msg-1',
+      sessionID: 'sess-1',
+      role: 'user',
+      time: { created: Date.now() },
+      agent: 'build',
+      model: { providerID: 'opencode', modelID: 'test-model' },
+    });
+    expect(withoutTemp.success).toBe(true);
+    if (withoutTemp.success) {
+      expect(withoutTemp.data.temperature).toBeUndefined();
+    }
+
+    // Valid user message with temperature
+    const withTemp = MessageV2.User.safeParse({
+      id: 'msg-2',
+      sessionID: 'sess-1',
+      role: 'user',
+      time: { created: Date.now() },
+      agent: 'build',
+      model: { providerID: 'opencode', modelID: 'test-model' },
+      temperature: 0.7,
+    });
+    expect(withTemp.success).toBe(true);
+    if (withTemp.success) {
+      expect(withTemp.data.temperature).toBe(0.7);
+    }
+  });
+
+  test('SessionPrompt.PromptInput schema accepts optional temperature field', async () => {
+    // Dynamically import to get the PromptInput schema
+    const { SessionPrompt } = await import('../src/session/prompt.ts');
+
+    // PromptInput with temperature
+    const result = SessionPrompt.PromptInput.safeParse({
+      sessionID: 'ses_test12345678901234',
+      temperature: 0.42,
+      parts: [{ type: 'text', text: 'hello' }],
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.temperature).toBe(0.42);
+    }
+
+    // PromptInput without temperature (existing behavior)
+    const noTemp = SessionPrompt.PromptInput.safeParse({
+      sessionID: 'ses_test12345678901234',
+      parts: [{ type: 'text', text: 'hello' }],
+    });
+    expect(noTemp.success).toBe(true);
+    if (noTemp.success) {
+      expect(noTemp.data.temperature).toBeUndefined();
+    }
+  });
+});
+
+describe('--temperature Rust CLI option (#241)', () => {
+  test('Rust Args struct includes optional temperature field', async () => {
+    // Read the Rust CLI source to verify the temperature field exists
+    const fs = await import('fs');
+    const cliSource = fs.readFileSync(
+      new URL('../../rust/src/cli.rs', import.meta.url),
+      'utf-8'
+    );
+
+    // Verify the temperature field is defined as Option<f64>
+    expect(cliSource).toContain('pub temperature: Option<f64>');
+    // Verify it has the correct arg attribute (no default value)
+    expect(cliSource).toContain('#[arg(long)]');
+    expect(cliSource).toContain('/// Override the temperature for model completions');
+  });
+});

--- a/rust/changelog.d/20260410_201700_add_temperature_option.md
+++ b/rust/changelog.d/20260410_201700_add_temperature_option.md
@@ -1,0 +1,7 @@
+---
+bump: minor
+---
+
+### Added
+
+- Added `--temperature` CLI option to override the temperature for model completions (#241)

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -49,6 +49,10 @@ pub struct Args {
     #[arg(long, default_value = "false")]
     pub compact_json: bool,
 
+    /// Override the temperature for model completions
+    #[arg(long)]
+    pub temperature: Option<f64>,
+
     /// Working directory
     #[arg(long)]
     pub working_directory: Option<PathBuf>,

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -12,50 +12,209 @@ use crate::error::{AgentError, Result};
 use crate::id::{ascending, Prefix};
 use crate::tool::{ToolContext, ToolRegistry};
 
+/// Default model used when no `--model` CLI argument is provided.
+pub const DEFAULT_MODEL: &str = "opencode/nemotron-3-super-free";
+
+/// Default compaction model used when no `--compaction-model` CLI argument is provided.
+/// gpt-5-nano has a 400K context window, larger than most free base models (~200K).
+pub const DEFAULT_COMPACTION_MODEL: &str = "opencode/gpt-5-nano";
+
+/// Default compaction models cascade, ordered from smallest/cheapest context to largest.
+/// During compaction, the system tries each model in order.
+pub const DEFAULT_COMPACTION_MODELS: &str =
+    "(big-pickle minimax-m2.5-free nemotron-3-super-free gpt-5-nano same)";
+
+/// Default compaction safety margin as a percentage of usable context window.
+pub const DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT: u32 = 15;
+
 /// Agent CLI - A minimal AI CLI agent compatible with OpenCode's JSON interface
 #[derive(Parser, Debug)]
 #[command(name = "agent")]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
     /// Model to use in format providerID/modelID
-    #[arg(long, default_value = "opencode/minimax-m2.5-free")]
+    #[arg(long, default_value = DEFAULT_MODEL)]
     pub model: String,
 
-    /// JSON output format standard
+    /// JSON output format standard: "opencode" (default) or "claude" (experimental)
     #[arg(long, default_value = "opencode", value_parser = ["opencode", "claude"])]
     pub json_standard: String,
 
-    /// Direct prompt (bypasses stdin reading)
-    #[arg(short = 'p', long)]
-    pub prompt: Option<String>,
-
-    /// System message override
+    /// Full override of the system message
     #[arg(long)]
     pub system_message: Option<String>,
 
-    /// Append to system message
+    /// Full override of the system message from file
+    #[arg(long)]
+    pub system_message_file: Option<String>,
+
+    /// Append to the default system message
     #[arg(long)]
     pub append_system_message: Option<String>,
 
-    /// Enable verbose mode
-    #[arg(long, default_value = "false")]
+    /// Append to the default system message from file
+    #[arg(long)]
+    pub append_system_message_file: Option<String>,
+
+    /// Run in server mode (default: true). Use --no-server to disable.
+    #[arg(long)]
+    server: bool,
+    #[arg(long = "no-server", hide = true)]
+    no_server: bool,
+
+    /// Enable verbose mode to debug API requests (shows system prompt, token counts, etc.)
+    #[arg(long)]
     pub verbose: bool,
 
-    /// Dry run mode (simulate without API calls)
-    #[arg(long, default_value = "false")]
+    /// Simulate operations without making actual API calls or package installations (useful for testing)
+    #[arg(long)]
     pub dry_run: bool,
 
-    /// Output compact JSON (single line)
-    #[arg(long, default_value = "false")]
+    /// Use existing Claude OAuth credentials from ~/.claude/.credentials.json (from Claude Code CLI)
+    #[arg(long)]
+    pub use_existing_claude_oauth: bool,
+
+    /// Prompt message to send directly (bypasses stdin reading)
+    #[arg(short = 'p', long)]
+    pub prompt: Option<String>,
+
+    /// Disable stdin streaming mode (requires --prompt or shows help)
+    #[arg(long)]
+    pub disable_stdin: bool,
+
+    /// Optional timeout in milliseconds for stdin reading (default: no timeout)
+    #[arg(long)]
+    pub stdin_stream_timeout: Option<u64>,
+
+    /// Enable auto-merging of rapidly arriving input lines into single messages (default: true).
+    /// Use --no-auto-merge-queued-messages to disable.
+    #[arg(long)]
+    auto_merge_queued_messages: bool,
+    #[arg(long = "no-auto-merge-queued-messages", hide = true)]
+    no_auto_merge_queued_messages: bool,
+
+    /// Enable interactive mode to accept manual input as plain text strings (default: true).
+    /// Use --no-interactive to only accept JSON input.
+    #[arg(long)]
+    interactive: bool,
+    #[arg(long = "no-interactive", hide = true)]
+    no_interactive: bool,
+
+    /// Keep accepting stdin input even after the agent finishes work (default: true).
+    /// Use --no-always-accept-stdin for single-message mode.
+    #[arg(long)]
+    always_accept_stdin: bool,
+    #[arg(long = "no-always-accept-stdin", hide = true)]
+    no_always_accept_stdin: bool,
+
+    /// Output compact JSON (single line) instead of pretty-printed JSON (default: false).
+    /// Useful for program-to-program communication.
+    #[arg(long)]
     pub compact_json: bool,
 
-    /// Override the temperature for model completions
+    /// Resume a specific session by ID. By default, forks the session with a new UUID.
+    /// Use --no-fork to continue in the same session.
+    #[arg(short = 'r', long)]
+    pub resume: Option<String>,
+
+    /// Continue the most recent session. By default, forks the session with a new UUID.
+    /// Use --no-fork to continue in the same session.
+    #[arg(short = 'c', long = "continue")]
+    pub continue_session: bool,
+
+    /// When used with --resume or --continue, continue in the same session without forking to a new UUID.
+    #[arg(long)]
+    pub no_fork: bool,
+
+    /// Generate session titles using AI (default: false). Disabling saves tokens and prevents rate limit issues.
+    #[arg(long)]
+    pub generate_title: bool,
+
+    /// Maximum total retry time in seconds for rate limit errors (default: 604800 = 7 days)
+    #[arg(long)]
+    pub retry_timeout: Option<u64>,
+
+    /// Retry AI completions API requests when rate limited (HTTP 429).
+    /// Use --no-retry-on-rate-limits in integration tests to fail fast instead of waiting.
+    #[arg(long)]
+    retry_on_rate_limits: bool,
+    #[arg(long = "no-retry-on-rate-limits", hide = true)]
+    no_retry_on_rate_limits: bool,
+
+    /// Include model info in step_finish output (default: true).
+    /// Use --no-output-response-model to disable.
+    #[arg(long)]
+    output_response_model: bool,
+    #[arg(long = "no-output-response-model", hide = true)]
+    no_output_response_model: bool,
+
+    /// Generate AI session summaries (default: true). Use --no-summarize-session to disable.
+    #[arg(long)]
+    summarize_session: bool,
+    #[arg(long = "no-summarize-session", hide = true)]
+    no_summarize_session: bool,
+
+    /// Model to use for context compaction in format providerID/modelID.
+    /// Use "same" to use the base model.
+    #[arg(long, default_value = DEFAULT_COMPACTION_MODEL)]
+    pub compaction_model: String,
+
+    /// Ordered cascade of compaction models in links notation sequence format.
+    /// Models are tried from smallest/cheapest context to largest.
+    /// The special value "same" uses the base model. Overrides --compaction-model when specified.
+    #[arg(long, default_value = DEFAULT_COMPACTION_MODELS)]
+    pub compaction_models: String,
+
+    /// Safety margin (%) of usable context window before triggering compaction.
+    /// Only applies when the compaction model has equal or smaller context than the base model.
+    #[arg(long, default_value_t = DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT)]
+    pub compaction_safety_margin: u32,
+
+    /// Override the temperature for model completions.
+    /// When not set, the default per-model temperature is used.
     #[arg(long)]
     pub temperature: Option<f64>,
 
     /// Working directory
     #[arg(long)]
     pub working_directory: Option<PathBuf>,
+}
+
+impl Args {
+    /// Effective server mode: defaults to true, --no-server sets to false
+    pub fn server(&self) -> bool {
+        !self.no_server
+    }
+
+    /// Effective auto-merge: defaults to true, --no-auto-merge-queued-messages sets to false
+    pub fn auto_merge_queued_messages(&self) -> bool {
+        !self.no_auto_merge_queued_messages
+    }
+
+    /// Effective interactive: defaults to true, --no-interactive sets to false
+    pub fn interactive(&self) -> bool {
+        !self.no_interactive
+    }
+
+    /// Effective always-accept-stdin: defaults to true, --no-always-accept-stdin sets to false
+    pub fn always_accept_stdin(&self) -> bool {
+        !self.no_always_accept_stdin
+    }
+
+    /// Effective retry-on-rate-limits: defaults to true, --no-retry-on-rate-limits sets to false
+    pub fn retry_on_rate_limits(&self) -> bool {
+        !self.no_retry_on_rate_limits
+    }
+
+    /// Effective output-response-model: defaults to true, --no-output-response-model sets to false
+    pub fn output_response_model(&self) -> bool {
+        !self.no_output_response_model
+    }
+
+    /// Effective summarize-session: defaults to true, --no-summarize-session sets to false
+    pub fn summarize_session(&self) -> bool {
+        !self.no_summarize_session
+    }
 }
 
 /// JSON input format
@@ -142,6 +301,37 @@ fn timestamp_ms() -> u64 {
         .as_millis() as u64
 }
 
+/// Read system message from file if specified
+fn read_system_message_file(path: &str) -> Result<String> {
+    std::fs::read_to_string(path).map_err(|e| AgentError::FileNotFound {
+        path: path.to_string(),
+        suggestions: vec![format!("Failed to read system message file: {}", e)],
+    })
+}
+
+/// Resolve the effective system message from CLI args (mirrors JS readSystemMessages)
+fn resolve_system_messages(args: &Args) -> Result<(Option<String>, Option<String>)> {
+    // Full override: --system-message or --system-message-file
+    let system_message = if let Some(ref msg) = args.system_message {
+        Some(msg.clone())
+    } else if let Some(ref path) = args.system_message_file {
+        Some(read_system_message_file(path)?)
+    } else {
+        None
+    };
+
+    // Append: --append-system-message or --append-system-message-file
+    let append_system_message = if let Some(ref msg) = args.append_system_message {
+        Some(msg.clone())
+    } else if let Some(ref path) = args.append_system_message_file {
+        Some(read_system_message_file(path)?)
+    } else {
+        None
+    };
+
+    Ok((system_message, append_system_message))
+}
+
 /// Run the CLI with parsed arguments
 pub async fn run(args: Args) -> Result<()> {
     let working_dir = args
@@ -149,15 +339,38 @@ pub async fn run(args: Args) -> Result<()> {
         .clone()
         .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
 
+    // Resolve system messages from file args if needed
+    let (system_message, append_system_message) = resolve_system_messages(&args)?;
+
+    // Handle --disable-stdin: requires --prompt or shows help
+    if args.disable_stdin && args.prompt.is_none() {
+        return Err(AgentError::invalid_arguments(
+            "cli",
+            "--disable-stdin requires --prompt to be set",
+        ));
+    }
+
     // Handle direct prompt mode
     if let Some(ref prompt) = args.prompt {
-        return run_with_input(&args, &working_dir, prompt).await;
+        return run_with_input(
+            &args,
+            &working_dir,
+            prompt,
+            system_message.as_deref(),
+            append_system_message.as_deref(),
+        )
+        .await;
     }
 
     // Output status
+    let mode = if args.server() {
+        "server"
+    } else {
+        "stdin-stream"
+    };
     output_event(
         &OutputEvent::Status {
-            mode: "stdin-stream".to_string(),
+            mode: mode.to_string(),
             message: "Agent CLI (Rust) ready. Accepts JSON and plain text input.".to_string(),
             hint: Some("Press CTRL+C to exit.".to_string()),
         },
@@ -174,13 +387,42 @@ pub async fn run(args: Args) -> Result<()> {
                     continue;
                 }
 
-                // Try to parse as JSON, otherwise treat as plain text
-                let message = match serde_json::from_str::<InputMessage>(trimmed) {
-                    Ok(msg) => msg.message,
-                    Err(_) => trimmed.to_string(),
+                // Try to parse as JSON if not in interactive mode, otherwise treat as plain text
+                let message = if args.interactive() {
+                    match serde_json::from_str::<InputMessage>(trimmed) {
+                        Ok(msg) => msg.message,
+                        Err(_) => trimmed.to_string(),
+                    }
+                } else {
+                    // Non-interactive mode: only accept JSON input
+                    match serde_json::from_str::<InputMessage>(trimmed) {
+                        Ok(msg) => msg.message,
+                        Err(e) => {
+                            output_event(
+                                &OutputEvent::Error {
+                                    timestamp: timestamp_ms(),
+                                    session_id: None,
+                                    error: serde_json::json!({
+                                        "name": "InvalidInput",
+                                        "data": { "message": format!("Expected JSON input in non-interactive mode: {}", e) }
+                                    }),
+                                },
+                                args.compact_json,
+                            );
+                            continue;
+                        }
+                    }
                 };
 
-                if let Err(e) = run_with_input(&args, &working_dir, &message).await {
+                if let Err(e) = run_with_input(
+                    &args,
+                    &working_dir,
+                    &message,
+                    system_message.as_deref(),
+                    append_system_message.as_deref(),
+                )
+                .await
+                {
                     output_event(
                         &OutputEvent::Error {
                             timestamp: timestamp_ms(),
@@ -189,6 +431,11 @@ pub async fn run(args: Args) -> Result<()> {
                         },
                         args.compact_json,
                     );
+                }
+
+                // In single-message mode (--no-always-accept-stdin), exit after first message
+                if !args.always_accept_stdin() {
+                    break;
                 }
             }
             Err(e) => {
@@ -211,7 +458,13 @@ pub async fn run(args: Args) -> Result<()> {
 }
 
 /// Run with a specific input message
-async fn run_with_input(args: &Args, working_dir: &PathBuf, message: &str) -> Result<()> {
+async fn run_with_input(
+    args: &Args,
+    working_dir: &PathBuf,
+    message: &str,
+    system_message: Option<&str>,
+    append_system_message: Option<&str>,
+) -> Result<()> {
     let session_id = ascending(Prefix::Session, None);
     let message_id = ascending(Prefix::Message, None);
 
@@ -224,7 +477,7 @@ async fn run_with_input(args: &Args, working_dir: &PathBuf, message: &str) -> Re
         args.compact_json,
     );
 
-    // Log temperature when verbose mode is on
+    // Log configuration when verbose mode is on
     if args.verbose {
         let temp_display = match args.temperature {
             Some(t) => format!("{}", t),
@@ -238,6 +491,132 @@ async fn run_with_input(args: &Args, working_dir: &PathBuf, message: &str) -> Re
             },
             args.compact_json,
         );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Model: {}", args.model),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("JSON standard: {}", args.json_standard),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Compaction model: {}", args.compaction_model),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Compaction models: {}", args.compaction_models),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!(
+                    "Compaction safety margin: {}%",
+                    args.compaction_safety_margin
+                ),
+            },
+            args.compact_json,
+        );
+
+        if let Some(sys_msg) = system_message {
+            output_event(
+                &OutputEvent::Text {
+                    timestamp: timestamp_ms(),
+                    session_id: session_id.clone(),
+                    text: format!("System message: {}", sys_msg),
+                },
+                args.compact_json,
+            );
+        }
+
+        if let Some(append_msg) = append_system_message {
+            output_event(
+                &OutputEvent::Text {
+                    timestamp: timestamp_ms(),
+                    session_id: session_id.clone(),
+                    text: format!("Append system message: {}", append_msg),
+                },
+                args.compact_json,
+            );
+        }
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Server mode: {}", args.server()),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Interactive: {}", args.interactive()),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Generate title: {}", args.generate_title),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Summarize session: {}", args.summarize_session()),
+            },
+            args.compact_json,
+        );
+
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("Retry on rate limits: {}", args.retry_on_rate_limits()),
+            },
+            args.compact_json,
+        );
+
+        if let Some(timeout) = args.retry_timeout {
+            output_event(
+                &OutputEvent::Text {
+                    timestamp: timestamp_ms(),
+                    session_id: session_id.clone(),
+                    text: format!("Retry timeout: {}s", timeout),
+                },
+                args.compact_json,
+            );
+        }
     }
 
     if args.dry_run {
@@ -256,7 +635,7 @@ async fn run_with_input(args: &Args, working_dir: &PathBuf, message: &str) -> Re
         );
     } else {
         // Create tool context
-        let ctx = ToolContext::new(&session_id, &message_id, working_dir);
+        let _ctx = ToolContext::new(&session_id, &message_id, working_dir);
 
         // Initialize tool registry
         let registry = ToolRegistry::new();
@@ -315,11 +694,39 @@ mod tests {
     #[test]
     fn test_args_defaults() {
         let args = Args::parse_from(["agent"]);
-        assert_eq!(args.model, "opencode/minimax-m2.5-free");
+        assert_eq!(args.model, DEFAULT_MODEL);
         assert_eq!(args.json_standard, "opencode");
+        assert!(args.server());
         assert!(!args.verbose);
         assert!(!args.dry_run);
+        assert!(!args.use_existing_claude_oauth);
+        assert!(args.prompt.is_none());
+        assert!(!args.disable_stdin);
+        assert!(args.stdin_stream_timeout.is_none());
+        assert!(args.auto_merge_queued_messages());
+        assert!(args.interactive());
+        assert!(args.always_accept_stdin());
+        assert!(!args.compact_json);
+        assert!(args.resume.is_none());
+        assert!(!args.continue_session);
+        assert!(!args.no_fork);
+        assert!(!args.generate_title);
+        assert!(args.retry_timeout.is_none());
+        assert!(args.retry_on_rate_limits());
+        assert!(args.output_response_model());
+        assert!(args.summarize_session());
+        assert_eq!(args.compaction_model, DEFAULT_COMPACTION_MODEL);
+        assert_eq!(args.compaction_models, DEFAULT_COMPACTION_MODELS);
+        assert_eq!(
+            args.compaction_safety_margin,
+            DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT
+        );
         assert!(args.temperature.is_none());
+        assert!(args.system_message.is_none());
+        assert!(args.system_message_file.is_none());
+        assert!(args.append_system_message.is_none());
+        assert!(args.append_system_message_file.is_none());
+        assert!(args.working_directory.is_none());
     }
 
     #[test]
@@ -357,5 +764,266 @@ mod tests {
         let args = Args::parse_from(["agent", "--temperature", "0.5", "-p", "hello"]);
         assert_eq!(args.temperature, Some(0.5));
         assert_eq!(args.prompt, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_args_model() {
+        let args = Args::parse_from(["agent", "--model", "opencode/gpt-5"]);
+        assert_eq!(args.model, "opencode/gpt-5");
+    }
+
+    #[test]
+    fn test_args_json_standard_claude() {
+        let args = Args::parse_from(["agent", "--json-standard", "claude"]);
+        assert_eq!(args.json_standard, "claude");
+    }
+
+    #[test]
+    fn test_args_system_message() {
+        let args = Args::parse_from(["agent", "--system-message", "You are helpful"]);
+        assert_eq!(args.system_message, Some("You are helpful".to_string()));
+    }
+
+    #[test]
+    fn test_args_system_message_file() {
+        let args = Args::parse_from(["agent", "--system-message-file", "/tmp/sys.txt"]);
+        assert_eq!(args.system_message_file, Some("/tmp/sys.txt".to_string()));
+    }
+
+    #[test]
+    fn test_args_append_system_message() {
+        let args = Args::parse_from(["agent", "--append-system-message", "extra instructions"]);
+        assert_eq!(
+            args.append_system_message,
+            Some("extra instructions".to_string())
+        );
+    }
+
+    #[test]
+    fn test_args_append_system_message_file() {
+        let args = Args::parse_from(["agent", "--append-system-message-file", "/tmp/append.txt"]);
+        assert_eq!(
+            args.append_system_message_file,
+            Some("/tmp/append.txt".to_string())
+        );
+    }
+
+    #[test]
+    fn test_args_server_mode() {
+        // Default is true
+        let args = Args::parse_from(["agent"]);
+        assert!(args.server());
+    }
+
+    #[test]
+    fn test_args_no_server() {
+        let args = Args::parse_from(["agent", "--no-server"]);
+        assert!(!args.server());
+    }
+
+    #[test]
+    fn test_args_verbose() {
+        let args = Args::parse_from(["agent", "--verbose"]);
+        assert!(args.verbose);
+    }
+
+    #[test]
+    fn test_args_dry_run() {
+        let args = Args::parse_from(["agent", "--dry-run"]);
+        assert!(args.dry_run);
+    }
+
+    #[test]
+    fn test_args_use_existing_claude_oauth() {
+        let args = Args::parse_from(["agent", "--use-existing-claude-oauth"]);
+        assert!(args.use_existing_claude_oauth);
+    }
+
+    #[test]
+    fn test_args_disable_stdin() {
+        let args = Args::parse_from(["agent", "--disable-stdin", "-p", "test"]);
+        assert!(args.disable_stdin);
+    }
+
+    #[test]
+    fn test_args_stdin_stream_timeout() {
+        let args = Args::parse_from(["agent", "--stdin-stream-timeout", "5000"]);
+        assert_eq!(args.stdin_stream_timeout, Some(5000));
+    }
+
+    #[test]
+    fn test_args_no_auto_merge_queued_messages() {
+        let args = Args::parse_from(["agent", "--no-auto-merge-queued-messages"]);
+        assert!(!args.auto_merge_queued_messages());
+    }
+
+    #[test]
+    fn test_args_no_interactive() {
+        let args = Args::parse_from(["agent", "--no-interactive"]);
+        assert!(!args.interactive());
+    }
+
+    #[test]
+    fn test_args_no_always_accept_stdin() {
+        let args = Args::parse_from(["agent", "--no-always-accept-stdin"]);
+        assert!(!args.always_accept_stdin());
+    }
+
+    #[test]
+    fn test_args_compact_json() {
+        let args = Args::parse_from(["agent", "--compact-json"]);
+        assert!(args.compact_json);
+    }
+
+    #[test]
+    fn test_args_resume() {
+        let args = Args::parse_from(["agent", "--resume", "ses_abc123"]);
+        assert_eq!(args.resume, Some("ses_abc123".to_string()));
+    }
+
+    #[test]
+    fn test_args_resume_short() {
+        let args = Args::parse_from(["agent", "-r", "ses_abc123"]);
+        assert_eq!(args.resume, Some("ses_abc123".to_string()));
+    }
+
+    #[test]
+    fn test_args_continue() {
+        let args = Args::parse_from(["agent", "--continue"]);
+        assert!(args.continue_session);
+    }
+
+    #[test]
+    fn test_args_continue_short() {
+        let args = Args::parse_from(["agent", "-c"]);
+        assert!(args.continue_session);
+    }
+
+    #[test]
+    fn test_args_no_fork() {
+        let args = Args::parse_from(["agent", "--no-fork", "--resume", "ses_abc"]);
+        assert!(args.no_fork);
+    }
+
+    #[test]
+    fn test_args_generate_title() {
+        let args = Args::parse_from(["agent", "--generate-title"]);
+        assert!(args.generate_title);
+    }
+
+    #[test]
+    fn test_args_retry_timeout() {
+        let args = Args::parse_from(["agent", "--retry-timeout", "3600"]);
+        assert_eq!(args.retry_timeout, Some(3600));
+    }
+
+    #[test]
+    fn test_args_no_retry_on_rate_limits() {
+        let args = Args::parse_from(["agent", "--no-retry-on-rate-limits"]);
+        assert!(!args.retry_on_rate_limits());
+    }
+
+    #[test]
+    fn test_args_no_output_response_model() {
+        let args = Args::parse_from(["agent", "--no-output-response-model"]);
+        assert!(!args.output_response_model());
+    }
+
+    #[test]
+    fn test_args_no_summarize_session() {
+        let args = Args::parse_from(["agent", "--no-summarize-session"]);
+        assert!(!args.summarize_session());
+    }
+
+    #[test]
+    fn test_args_compaction_model() {
+        let args = Args::parse_from(["agent", "--compaction-model", "opencode/gpt-5"]);
+        assert_eq!(args.compaction_model, "opencode/gpt-5");
+    }
+
+    #[test]
+    fn test_args_compaction_models() {
+        let args = Args::parse_from(["agent", "--compaction-models", "(model1 model2 same)"]);
+        assert_eq!(args.compaction_models, "(model1 model2 same)");
+    }
+
+    #[test]
+    fn test_args_compaction_safety_margin() {
+        let args = Args::parse_from(["agent", "--compaction-safety-margin", "20"]);
+        assert_eq!(args.compaction_safety_margin, 20);
+    }
+
+    #[test]
+    fn test_args_all_options_combined() {
+        let args = Args::parse_from([
+            "agent",
+            "--model",
+            "opencode/gpt-5",
+            "--json-standard",
+            "claude",
+            "--system-message",
+            "Be helpful",
+            "--verbose",
+            "--dry-run",
+            "--compact-json",
+            "--temperature",
+            "0.8",
+            "--compaction-model",
+            "same",
+            "--compaction-safety-margin",
+            "10",
+            "--no-interactive",
+            "--no-always-accept-stdin",
+            "--no-retry-on-rate-limits",
+            "--retry-timeout",
+            "60",
+            "--generate-title",
+            "--no-summarize-session",
+            "-p",
+            "test prompt",
+        ]);
+        assert_eq!(args.model, "opencode/gpt-5");
+        assert_eq!(args.json_standard, "claude");
+        assert_eq!(args.system_message, Some("Be helpful".to_string()));
+        assert!(args.verbose);
+        assert!(args.dry_run);
+        assert!(args.compact_json);
+        assert_eq!(args.temperature, Some(0.8));
+        assert_eq!(args.compaction_model, "same");
+        assert_eq!(args.compaction_safety_margin, 10);
+        assert!(!args.interactive());
+        assert!(!args.always_accept_stdin());
+        assert!(!args.retry_on_rate_limits());
+        assert_eq!(args.retry_timeout, Some(60));
+        assert!(args.generate_title);
+        assert!(!args.summarize_session());
+        assert_eq!(args.prompt, Some("test prompt".to_string()));
+    }
+
+    #[test]
+    fn test_default_model_matches_js() {
+        // Ensures Rust default model matches JavaScript DEFAULT_MODEL
+        assert_eq!(DEFAULT_MODEL, "opencode/nemotron-3-super-free");
+    }
+
+    #[test]
+    fn test_default_compaction_model_matches_js() {
+        // Ensures Rust default compaction model matches JavaScript DEFAULT_COMPACTION_MODEL
+        assert_eq!(DEFAULT_COMPACTION_MODEL, "opencode/gpt-5-nano");
+    }
+
+    #[test]
+    fn test_default_compaction_models_matches_js() {
+        // Ensures Rust default compaction models matches JavaScript DEFAULT_COMPACTION_MODELS
+        assert_eq!(
+            DEFAULT_COMPACTION_MODELS,
+            "(big-pickle minimax-m2.5-free nemotron-3-super-free gpt-5-nano same)"
+        );
+    }
+
+    #[test]
+    fn test_default_compaction_safety_margin_matches_js() {
+        // Ensures Rust default compaction safety margin matches JavaScript
+        assert_eq!(DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT, 15);
     }
 }

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -224,13 +224,33 @@ async fn run_with_input(args: &Args, working_dir: &PathBuf, message: &str) -> Re
         args.compact_json,
     );
 
-    if args.dry_run {
-        // In dry run mode, just echo the message
+    // Log temperature when verbose mode is on
+    if args.verbose {
+        let temp_display = match args.temperature {
+            Some(t) => format!("{}", t),
+            None => "default".to_string(),
+        };
         output_event(
             &OutputEvent::Text {
                 timestamp: timestamp_ms(),
                 session_id: session_id.clone(),
-                text: format!("[DRY RUN] Received message: {}", message),
+                text: format!("Temperature: {}", temp_display),
+            },
+            args.compact_json,
+        );
+    }
+
+    if args.dry_run {
+        // In dry run mode, echo the message and show configuration
+        let temp_info = match args.temperature {
+            Some(t) => format!(", temperature: {}", t),
+            None => String::new(),
+        };
+        output_event(
+            &OutputEvent::Text {
+                timestamp: timestamp_ms(),
+                session_id: session_id.clone(),
+                text: format!("[DRY RUN] Received message: {}{}", message, temp_info),
             },
             args.compact_json,
         );
@@ -299,11 +319,43 @@ mod tests {
         assert_eq!(args.json_standard, "opencode");
         assert!(!args.verbose);
         assert!(!args.dry_run);
+        assert!(args.temperature.is_none());
     }
 
     #[test]
     fn test_args_with_prompt() {
         let args = Args::parse_from(["agent", "-p", "hello"]);
+        assert_eq!(args.prompt, Some("hello".to_string()));
+    }
+
+    #[test]
+    fn test_args_temperature_not_set() {
+        let args = Args::parse_from(["agent"]);
+        assert!(args.temperature.is_none());
+    }
+
+    #[test]
+    fn test_args_temperature_float() {
+        let args = Args::parse_from(["agent", "--temperature", "0.7"]);
+        assert_eq!(args.temperature, Some(0.7));
+    }
+
+    #[test]
+    fn test_args_temperature_zero() {
+        let args = Args::parse_from(["agent", "--temperature", "0"]);
+        assert_eq!(args.temperature, Some(0.0));
+    }
+
+    #[test]
+    fn test_args_temperature_one() {
+        let args = Args::parse_from(["agent", "--temperature", "1.0"]);
+        assert_eq!(args.temperature, Some(1.0));
+    }
+
+    #[test]
+    fn test_args_temperature_with_prompt() {
+        let args = Args::parse_from(["agent", "--temperature", "0.5", "-p", "hello"]);
+        assert_eq!(args.temperature, Some(0.5));
         assert_eq!(args.prompt, Some("hello".to_string()));
     }
 }

--- a/rust/tests/cli_options.rs
+++ b/rust/tests/cli_options.rs
@@ -1,0 +1,650 @@
+//! Integration tests for all CLI options.
+//!
+//! Verifies that the Rust CLI binary supports the same set of CLI options
+//! as the JavaScript implementation, ensuring full feature parity.
+//! Each option is tested via the compiled binary using assert_cmd.
+
+use assert_cmd::cargo_bin_cmd;
+use predicates::prelude::*;
+use std::io::Write;
+
+/// Helper to create a Command for the agent binary.
+fn agent_cmd() -> assert_cmd::Command {
+    cargo_bin_cmd!()
+}
+
+// ── Model option ──────────────────────────────────────────────────────
+
+#[test]
+fn model_option_default() {
+    // Default model should be opencode/nemotron-3-super-free (matching JS).
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Model: opencode/nemotron-3-super-free",
+        ));
+}
+
+#[test]
+fn model_option_custom() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--model",
+            "opencode/gpt-5",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Model: opencode/gpt-5"));
+}
+
+// ── JSON standard option ─────────────────────────────────────────────
+
+#[test]
+fn json_standard_default() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("JSON standard: opencode"));
+}
+
+#[test]
+fn json_standard_claude() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--json-standard",
+            "claude",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("JSON standard: claude"));
+}
+
+#[test]
+fn json_standard_rejects_invalid() {
+    agent_cmd()
+        .args(["--dry-run", "--json-standard", "xml", "-p", "hello"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}
+
+// ── System message options ───────────────────────────────────────────
+
+#[test]
+fn system_message_option() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--system-message",
+            "You are a test bot",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "System message: You are a test bot",
+        ));
+}
+
+#[test]
+fn system_message_file_option() {
+    // Create a temp file with system message content
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    write!(tmpfile, "System from file").unwrap();
+    let path = tmpfile.path().to_str().unwrap().to_string();
+
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--system-message-file",
+            &path,
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("System message: System from file"));
+}
+
+#[test]
+fn append_system_message_option() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--append-system-message",
+            "Extra instructions",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Append system message: Extra instructions",
+        ));
+}
+
+#[test]
+fn append_system_message_file_option() {
+    let mut tmpfile = tempfile::NamedTempFile::new().unwrap();
+    write!(tmpfile, "Appended from file").unwrap();
+    let path = tmpfile.path().to_str().unwrap().to_string();
+
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--append-system-message-file",
+            &path,
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Append system message: Appended from file",
+        ));
+}
+
+#[test]
+fn system_message_file_not_found() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--system-message-file",
+            "/tmp/nonexistent_file_12345.txt",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .failure();
+}
+
+// ── Server mode option ───────────────────────────────────────────────
+
+#[test]
+fn server_mode_default_true() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Server mode: true"));
+}
+
+#[test]
+fn server_mode_disabled() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "--no-server", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Server mode: false"));
+}
+
+// ── Verbose option ───────────────────────────────────────────────────
+
+#[test]
+fn verbose_shows_config() {
+    // When verbose is on, many config values should be displayed.
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Model:"))
+        .stdout(predicate::str::contains("JSON standard:"))
+        .stdout(predicate::str::contains("Compaction model:"))
+        .stdout(predicate::str::contains("Compaction models:"))
+        .stdout(predicate::str::contains("Compaction safety margin:"))
+        .stdout(predicate::str::contains("Interactive:"))
+        .stdout(predicate::str::contains("Generate title:"))
+        .stdout(predicate::str::contains("Summarize session:"))
+        .stdout(predicate::str::contains("Retry on rate limits:"));
+}
+
+#[test]
+fn verbose_off_hides_config() {
+    // Without verbose, config lines should NOT appear.
+    agent_cmd()
+        .args(["--dry-run", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Model:").not())
+        .stdout(predicate::str::contains("JSON standard:").not());
+}
+
+// ── Dry run option ───────────────────────────────────────────────────
+
+#[test]
+fn dry_run_echoes_message() {
+    agent_cmd()
+        .args(["--dry-run", "-p", "test message"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "[DRY RUN] Received message: test message",
+        ));
+}
+
+// ── Use existing Claude OAuth option ─────────────────────────────────
+
+#[test]
+fn use_existing_claude_oauth_accepted() {
+    agent_cmd()
+        .args(["--dry-run", "--use-existing-claude-oauth", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+// ── Prompt option ────────────────────────────────────────────────────
+
+#[test]
+fn prompt_short_flag() {
+    agent_cmd()
+        .args(["--dry-run", "-p", "short flag test"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("short flag test"));
+}
+
+#[test]
+fn prompt_long_flag() {
+    agent_cmd()
+        .args(["--dry-run", "--prompt", "long flag test"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("long flag test"));
+}
+
+// ── Disable stdin option ─────────────────────────────────────────────
+
+#[test]
+fn disable_stdin_with_prompt_succeeds() {
+    agent_cmd()
+        .args(["--dry-run", "--disable-stdin", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn disable_stdin_without_prompt_fails() {
+    agent_cmd()
+        .args(["--dry-run", "--disable-stdin"])
+        .assert()
+        .failure();
+}
+
+// ── Stdin stream timeout option ──────────────────────────────────────
+
+#[test]
+fn stdin_stream_timeout_accepted() {
+    agent_cmd()
+        .args(["--dry-run", "--stdin-stream-timeout", "5000", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+// ── Auto merge queued messages option ────────────────────────────────
+
+#[test]
+fn auto_merge_queued_messages_default() {
+    agent_cmd()
+        .args(["--dry-run", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn no_auto_merge_queued_messages() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--no-auto-merge-queued-messages",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success();
+}
+
+// ── Interactive option ───────────────────────────────────────────────
+
+#[test]
+fn interactive_default_true() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Interactive: true"));
+}
+
+#[test]
+fn no_interactive() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "--no-interactive", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Interactive: false"));
+}
+
+// ── Always accept stdin option ───────────────────────────────────────
+
+#[test]
+fn no_always_accept_stdin() {
+    agent_cmd()
+        .args(["--dry-run", "--no-always-accept-stdin", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+// ── Compact JSON option ──────────────────────────────────────────────
+
+#[test]
+fn compact_json_single_line() {
+    let output = agent_cmd()
+        .args(["--dry-run", "--compact-json", "-p", "hello"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    // In compact mode, each JSON event should be on a single line
+    for line in stdout.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        // Each non-empty line should be valid JSON
+        assert!(
+            serde_json::from_str::<serde_json::Value>(line).is_ok(),
+            "Expected valid JSON on single line, got: {}",
+            line
+        );
+    }
+}
+
+// ── Resume option ────────────────────────────────────────────────────
+
+#[test]
+fn resume_option_accepted() {
+    agent_cmd()
+        .args(["--dry-run", "--resume", "ses_abc123", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn resume_short_flag() {
+    agent_cmd()
+        .args(["--dry-run", "-r", "ses_abc123", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+// ── Continue option ──────────────────────────────────────────────────
+
+#[test]
+fn continue_option_accepted() {
+    agent_cmd()
+        .args(["--dry-run", "--continue", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn continue_short_flag() {
+    agent_cmd()
+        .args(["--dry-run", "-c", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+// ── No fork option ───────────────────────────────────────────────────
+
+#[test]
+fn no_fork_option_accepted() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--no-fork",
+            "--resume",
+            "ses_abc",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success();
+}
+
+// ── Generate title option ────────────────────────────────────────────
+
+#[test]
+fn generate_title_option() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "--generate-title", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Generate title: true"));
+}
+
+// ── Retry timeout option ─────────────────────────────────────────────
+
+#[test]
+fn retry_timeout_option() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--retry-timeout",
+            "3600",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Retry timeout: 3600s"));
+}
+
+// ── Retry on rate limits option ──────────────────────────────────────
+
+#[test]
+fn retry_on_rate_limits_default_true() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Retry on rate limits: true"));
+}
+
+#[test]
+fn no_retry_on_rate_limits() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--no-retry-on-rate-limits",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Retry on rate limits: false"));
+}
+
+// ── Output response model option ─────────────────────────────────────
+
+#[test]
+fn output_response_model_accepted() {
+    agent_cmd()
+        .args(["--dry-run", "--no-output-response-model", "-p", "hello"])
+        .assert()
+        .success();
+}
+
+// ── Summarize session option ─────────────────────────────────────────
+
+#[test]
+fn summarize_session_default() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Summarize session: true"));
+}
+
+#[test]
+fn no_summarize_session() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--no-summarize-session",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Summarize session: false"));
+}
+
+// ── Compaction model option ──────────────────────────────────────────
+
+#[test]
+fn compaction_model_default() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Compaction model: opencode/gpt-5-nano",
+        ));
+}
+
+#[test]
+fn compaction_model_custom() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--compaction-model",
+            "same",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Compaction model: same"));
+}
+
+// ── Compaction models option ─────────────────────────────────────────
+
+#[test]
+fn compaction_models_default() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(
+            "Compaction models: (big-pickle minimax-m2.5-free nemotron-3-super-free gpt-5-nano same)",
+        ));
+}
+
+#[test]
+fn compaction_models_custom() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--compaction-models",
+            "(model1 same)",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Compaction models: (model1 same)"));
+}
+
+// ── Compaction safety margin option ──────────────────────────────────
+
+#[test]
+fn compaction_safety_margin_default() {
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Compaction safety margin: 15%"));
+}
+
+#[test]
+fn compaction_safety_margin_custom() {
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--compaction-safety-margin",
+            "25",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Compaction safety margin: 25%"));
+}
+
+// ── All options combined ─────────────────────────────────────────────
+
+#[test]
+fn all_options_accepted_together() {
+    // Verify that the binary accepts all options simultaneously without conflict.
+    agent_cmd()
+        .args([
+            "--model",
+            "opencode/gpt-5",
+            "--json-standard",
+            "claude",
+            "--system-message",
+            "Be helpful",
+            "--verbose",
+            "--dry-run",
+            "--use-existing-claude-oauth",
+            "--compact-json",
+            "--no-interactive",
+            "--no-always-accept-stdin",
+            "--no-auto-merge-queued-messages",
+            "--generate-title",
+            "--no-retry-on-rate-limits",
+            "--retry-timeout",
+            "60",
+            "--no-output-response-model",
+            "--no-summarize-session",
+            "--compaction-model",
+            "same",
+            "--compaction-models",
+            "(same)",
+            "--compaction-safety-margin",
+            "20",
+            "--temperature",
+            "0.5",
+            "--no-server",
+            "--no-fork",
+            "--resume",
+            "ses_abc",
+            "--stdin-stream-timeout",
+            "1000",
+            "--disable-stdin",
+            "-p",
+            "test",
+        ])
+        .assert()
+        .success();
+}

--- a/rust/tests/temperature_option.rs
+++ b/rust/tests/temperature_option.rs
@@ -1,0 +1,68 @@
+//! Integration tests for the --temperature CLI option.
+//!
+//! Issue #241: Add --temperature option that overrides the per-model and
+//! per-agent temperature defaults. When not set, existing behavior must
+//! remain unchanged.
+//!
+//! These tests verify the Rust CLI binary accepts and parses the
+//! --temperature flag correctly, mirroring the JavaScript test suite.
+
+use assert_cmd::cargo_bin_cmd;
+use predicates::prelude::*;
+
+/// Helper to create a Command for the agent binary.
+fn agent_cmd() -> assert_cmd::Command {
+    cargo_bin_cmd!()
+}
+
+#[test]
+fn temperature_option_not_required() {
+    // When --temperature is not provided, the agent should start normally.
+    // Use --dry-run and --prompt to get a quick deterministic response.
+    agent_cmd()
+        .args(["--dry-run", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[DRY RUN]"));
+}
+
+#[test]
+fn temperature_option_accepts_float_value() {
+    // When --temperature is provided with a valid float, the agent should
+    // accept it without error.
+    agent_cmd()
+        .args(["--dry-run", "--temperature", "0.7", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[DRY RUN]"));
+}
+
+#[test]
+fn temperature_option_accepts_zero() {
+    // Temperature 0 should be accepted (deterministic output use case).
+    agent_cmd()
+        .args(["--dry-run", "--temperature", "0", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[DRY RUN]"));
+}
+
+#[test]
+fn temperature_option_accepts_one() {
+    // Temperature 1.0 should be accepted.
+    agent_cmd()
+        .args(["--dry-run", "--temperature", "1.0", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("[DRY RUN]"));
+}
+
+#[test]
+fn temperature_option_rejects_non_numeric() {
+    // --temperature with a non-numeric value should fail with an error.
+    agent_cmd()
+        .args(["--dry-run", "--temperature", "hot", "-p", "hello"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value"));
+}

--- a/rust/tests/temperature_option.rs
+++ b/rust/tests/temperature_option.rs
@@ -29,12 +29,13 @@ fn temperature_option_not_required() {
 #[test]
 fn temperature_option_accepts_float_value() {
     // When --temperature is provided with a valid float, the agent should
-    // accept it without error.
+    // accept it without error and include the temperature in dry-run output.
     agent_cmd()
         .args(["--dry-run", "--temperature", "0.7", "-p", "hello"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("[DRY RUN]"));
+        .stdout(predicate::str::contains("[DRY RUN]"))
+        .stdout(predicate::str::contains("temperature: 0.7"));
 }
 
 #[test]
@@ -44,7 +45,8 @@ fn temperature_option_accepts_zero() {
         .args(["--dry-run", "--temperature", "0", "-p", "hello"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("[DRY RUN]"));
+        .stdout(predicate::str::contains("[DRY RUN]"))
+        .stdout(predicate::str::contains("temperature: 0"));
 }
 
 #[test]
@@ -54,7 +56,8 @@ fn temperature_option_accepts_one() {
         .args(["--dry-run", "--temperature", "1.0", "-p", "hello"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("[DRY RUN]"));
+        .stdout(predicate::str::contains("[DRY RUN]"))
+        .stdout(predicate::str::contains("temperature: 1"));
 }
 
 #[test]
@@ -65,4 +68,42 @@ fn temperature_option_rejects_non_numeric() {
         .assert()
         .failure()
         .stderr(predicate::str::contains("invalid value"));
+}
+
+#[test]
+fn temperature_option_not_shown_when_unset() {
+    // When --temperature is not provided, it should NOT appear in the output.
+    // This ensures the existing behavior is unchanged.
+    agent_cmd()
+        .args(["--dry-run", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("temperature:").not());
+}
+
+#[test]
+fn temperature_option_verbose_logging() {
+    // When --verbose is enabled and temperature is set, it should appear in verbose output.
+    agent_cmd()
+        .args([
+            "--dry-run",
+            "--verbose",
+            "--temperature",
+            "0.42",
+            "-p",
+            "hello",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Temperature: 0.42"));
+}
+
+#[test]
+fn temperature_option_verbose_default_when_unset() {
+    // When --verbose is enabled but temperature is NOT set, verbose output shows "default".
+    agent_cmd()
+        .args(["--dry-run", "--verbose", "-p", "hello"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Temperature: default"));
 }


### PR DESCRIPTION
## Summary

Fixes #241

- Added `--temperature` CLI option to both JavaScript and Rust implementations
- When set, overrides per-model and per-agent temperature defaults with the user-specified value
- When **not** set, existing behavior is completely unchanged (no default value)
- Temperature priority chain: `CLI --temperature` > `agent config` > `ProviderTransform` model defaults
- **Fully synced Rust CLI with all 29 JavaScript CLI options** (was 10, now 29)

## Changes

| File | Change |
| ---- | ------ |
| `js/src/cli/run-options.js` | Added `--temperature` yargs option (type: number, no default) |
| `js/src/session/prompt.ts` | Added `temperature` to `PromptInput` schema; CLI temperature takes highest priority |
| `js/src/session/message-v2.ts` | Added optional `temperature` field to `User` message schema |
| `js/src/index.js` | Passes `argv.temperature` through all mode variants |
| `js/src/cli/continuous-mode.js` | Passes `temperature` through continuous mode variants |
| `rust/src/cli.rs` | **All 29 JS CLI options now in Rust** with full `--no-*` negation support; defaults constants synced with JS; verbose logging of all config; system message file reading; interactive/non-interactive modes; single-message mode; 92 unit tests |
| `rust/tests/cli_options.rs` | **46 integration tests** covering all CLI options via compiled binary |
| `rust/tests/temperature_option.rs` | 8 integration tests for `--temperature` specifically |
| `js/tests/temperature-option.test.ts` | 5 tests covering schemas, defaults, and Rust struct |
| `js/.changeset/add-temperature-option-241.md` | Changeset for minor release |
| `rust/changelog.d/20260410_201700_add_temperature_option.md` | Rust changelog fragment for minor release |
| `docs/case-studies/issue-241/README.md` | Case study with requirements, research, and architecture |

## JS ↔ Rust full sync (29/29 options)

The Rust CLI now implements **all 29** JavaScript CLI options:

| # | Option | JS Type | Rust Type | Default | `--no-*` support |
|---|--------|---------|-----------|---------|------------------|
| 1 | `--model` | string | `String` | `opencode/nemotron-3-super-free` | — |
| 2 | `--json-standard` | string | `String` | `opencode` | — |
| 3 | `--system-message` | string | `Option<String>` | none | — |
| 4 | `--system-message-file` | string | `Option<String>` | none | — |
| 5 | `--append-system-message` | string | `Option<String>` | none | — |
| 6 | `--append-system-message-file` | string | `Option<String>` | none | — |
| 7 | `--server` | boolean | `bool` | `true` | ✅ `--no-server` |
| 8 | `--verbose` | boolean | `bool` | `false` | — |
| 9 | `--dry-run` | boolean | `bool` | `false` | — |
| 10 | `--use-existing-claude-oauth` | boolean | `bool` | `false` | — |
| 11 | `-p, --prompt` | string | `Option<String>` | none | — |
| 12 | `--disable-stdin` | boolean | `bool` | `false` | — |
| 13 | `--stdin-stream-timeout` | number | `Option<u64>` | none | — |
| 14 | `--auto-merge-queued-messages` | boolean | `bool` | `true` | ✅ `--no-auto-merge-queued-messages` |
| 15 | `--interactive` | boolean | `bool` | `true` | ✅ `--no-interactive` |
| 16 | `--always-accept-stdin` | boolean | `bool` | `true` | ✅ `--no-always-accept-stdin` |
| 17 | `--compact-json` | boolean | `bool` | `false` | — |
| 18 | `-r, --resume` | string | `Option<String>` | none | — |
| 19 | `-c, --continue` | boolean | `bool` | `false` | — |
| 20 | `--no-fork` | boolean | `bool` | `false` | — |
| 21 | `--generate-title` | boolean | `bool` | `false` | — |
| 22 | `--retry-timeout` | number | `Option<u64>` | none | — |
| 23 | `--retry-on-rate-limits` | boolean | `bool` | `true` | ✅ `--no-retry-on-rate-limits` |
| 24 | `--output-response-model` | boolean | `bool` | `true` | ✅ `--no-output-response-model` |
| 25 | `--summarize-session` | boolean | `bool` | `true` | ✅ `--no-summarize-session` |
| 26 | `--compaction-model` | string | `String` | `opencode/gpt-5-nano` | — |
| 27 | `--compaction-models` | string | `String` | `(big-pickle minimax-m2.5-free nemotron-3-super-free gpt-5-nano same)` | — |
| 28 | `--compaction-safety-margin` | number | `u32` | `15` | — |
| 29 | `--temperature` | number | `Option<f64>` | none | — |

### How Rust uses all options

1. **Verbose mode**: Logs all config values (model, JSON standard, temperature, compaction settings, server mode, interactive, generate-title, summarize-session, retry-on-rate-limits, retry-timeout, system messages)
2. **Dry-run mode**: Echoes received message with temperature info
3. **`--disable-stdin`**: Validates that `--prompt` is also set, errors otherwise
4. **`--no-interactive`**: Only accepts JSON input, rejects plain text with error
5. **`--no-always-accept-stdin`**: Exits after processing first message
6. **`--system-message-file` / `--append-system-message-file`**: Reads content from filesystem
7. **`--no-server`**: Changes status output mode from "server" to "stdin-stream"
8. **Default constants**: `DEFAULT_MODEL`, `DEFAULT_COMPACTION_MODEL`, `DEFAULT_COMPACTION_MODELS`, `DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT` all match JS values

## Test plan

- [x] `bun test tests/temperature-option.test.ts` — 5/5 pass
- [x] `cargo test --all-features` — 146/146 pass (92 unit + 46 cli_options integration + 8 temperature integration)
- [x] `bun run lint` — no errors
- [x] `bun run format:check` — all files formatted
- [x] `cargo fmt --all -- --check` — all files formatted
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [x] All Rust integration tests in separate `rust/tests/` directory (not in `src/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)