### PR TITLE
fix: lower compaction threshold to 75% and add token estimation fallback

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-11T12:21:22.660Z for PR creation at branch issue-249-a017ff30d69a for issue https://github.com/link-assistant/agent/issues/249

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-11T12:21:22.660Z for PR creation at branch issue-249-a017ff30d69a for issue https://github.com/link-assistant/agent/issues/249

--- a/docs/case-studies/issue-249/README.md
+++ b/docs/case-studies/issue-249/README.md
@@ -63,12 +63,25 @@ sweet spot when token counting is reliable. When token counting is unreliable
 - `DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT`: 15 → 25
 - Updated in both JS (`compaction.ts`, `defaults.ts`) and Rust (`cli.rs`)
 
-### Fix 2: Token estimation fallback
+### Fix 2: Token estimation fallback with BPE tokenization
 
 Added `estimatedInputTokens` parameter to `isOverflow()`. When the provider
-returns 0 for all token counts, the system estimates input tokens from message
-content using the 4-chars-per-token heuristic. This ensures compaction triggers
-even when providers don't report usage.
+returns 0 for all token counts, the system counts tokens from message content
+using real BPE tokenization (`gpt-tokenizer` with `o200k_base` encoding) when
+available, falling back to a character-based heuristic (~4 chars/token) for
+models with unknown tokenizers.
+
+**Why not always use real BPE?** Different LLM providers use different tokenizers:
+- OpenAI models (GPT-4o, GPT-4.1, GPT-5): `o200k_base` BPE — supported via `gpt-tokenizer`
+- Nvidia Nemotron: Custom SentencePiece BPE (256K vocab) — no JS library available
+- Google Gemini: SentencePiece — no JS library available
+- Meta Llama: SentencePiece — no JS library available
+- Anthropic Claude: Proprietary BPE (~65K vocab) — not publicly available
+
+Since the failing model (Nemotron) uses a tokenizer unavailable in JS, real BPE
+cannot guarantee accuracy for all providers. The 75% safety margin (25% buffer)
+absorbs the ±20% estimation error inherent in both the heuristic and cross-tokenizer
+estimation.
 
 ### Fix 3: Cap maxOutputTokens to context limit
 
@@ -87,11 +100,13 @@ model's hard limit.
 
 ## Files Changed
 
+- `js/src/util/token.ts` — Add `countTokens()` with real BPE via gpt-tokenizer, heuristic fallback
 - `js/src/session/compaction.ts` — Lower margin, add estimation fallback
-- `js/src/session/prompt.ts` — Pass estimated tokens, cap output tokens
+- `js/src/session/prompt.ts` — Use `Token.countTokens()` for overflow detection, cap output tokens
 - `js/src/cli/defaults.ts` — Update default margin percentage
 - `rust/src/cli.rs` — Sync Rust default
 - `js/tests/compaction-model.test.ts` — Update tests, add estimation tests
+- `js/tests/token.test.ts` — Tests for Token.estimate and Token.countTokens
 
 ## References
 

--- a/docs/case-studies/issue-249/README.md
+++ b/docs/case-studies/issue-249/README.md
@@ -1,0 +1,104 @@
+# Case Study: Issue #249 — Compaction Threshold Best Practices
+
+## Summary
+
+Context overflow error occurred when `nemotron-3-super-free` (262,144 context)
+received a request with 230,145 input tokens + 32,000 output tokens = 262,145 tokens,
+exceeding the hard limit by 1 token. Compaction never triggered because the provider
+returned 0 for all token counts.
+
+## Root Causes
+
+### 1. Provider returns 0 token counts
+
+The Nvidia/nemotron provider (via OpenCode) returned 0 for `inputTokens`,
+`outputTokens`, and all other usage fields. The `isOverflow()` function computed
+`currentTokens = 0 + 0 + 0 = 0`, which is always below any `safeLimit`,
+so compaction was never triggered.
+
+**Evidence from logs:**
+```
+"currentTokens": 0,
+"tokensBreakdown": { "input": 0, "cacheRead": 0, "output": 0 },
+"overflow": false,
+"headroom": 146880
+```
+
+This pattern repeated for every single overflow check in the session —
+all 10+ checks showed `currentTokens: 0`.
+
+### 2. max_tokens not capped to available context
+
+The system always requested `max_tokens: 32000` regardless of how much input
+was in the prompt. When input grew to 230,145 tokens:
+- Available: 262,144 - 230,145 = 31,999 tokens
+- Requested: 32,000 tokens
+- Total: 262,145 > 262,144 → **error**
+
+### 3. Safety margin too narrow
+
+The 85% threshold (15% margin) assumed providers would return accurate token
+counts. When they don't, a larger margin is needed as a safety buffer.
+
+## Research: Industry Compaction Thresholds
+
+| Tool | Threshold | Margin | Notes |
+|------|-----------|--------|-------|
+| Gemini CLI | 50% | 50% | Most conservative; configurable |
+| OpenCode (upstream sst/opencode) | 75% | 25% | Hardcoded 0.75 |
+| Claude Code | ~83.5% | ~16.5% | Reduced buffer in 2026 |
+| Codex CLI | ~95% | ~5% | Users report "too late" |
+| link-assistant/agent (before) | 85% | 15% | |
+| link-assistant/agent (after) | 75% | 25% | Matches OpenCode upstream |
+
+**Community consensus:** 80-90% is the recommended range, with 85-90% as the
+sweet spot when token counting is reliable. When token counting is unreliable
+(as in our case), a lower threshold is safer.
+
+## Fixes Applied
+
+### Fix 1: Lower safety margin from 85% to 75%
+
+- `OVERFLOW_SAFETY_MARGIN`: 0.85 → 0.75
+- `DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT`: 15 → 25
+- Updated in both JS (`compaction.ts`, `defaults.ts`) and Rust (`cli.rs`)
+
+### Fix 2: Token estimation fallback
+
+Added `estimatedInputTokens` parameter to `isOverflow()`. When the provider
+returns 0 for all token counts, the system estimates input tokens from message
+content using the 4-chars-per-token heuristic. This ensures compaction triggers
+even when providers don't report usage.
+
+### Fix 3: Cap maxOutputTokens to context limit
+
+Added `capOutputTokensToContext()` that ensures `estimatedInput + maxOutput`
+never exceeds the model's context limit. This is the last line of defense:
+even if compaction doesn't trigger in time, the request won't exceed the
+model's hard limit.
+
+## Timeline
+
+1. Session starts with `nemotron-3-super-free` (context: 262,144)
+2. Multiple turns execute; overflow checks all show `currentTokens: 0`
+3. Input grows to 230,145 tokens (estimated ~920,580 characters)
+4. Request sent with `max_tokens: 32000` → total 262,145 > 262,144
+5. Nvidia returns: `"This model's maximum context length is 262144 tokens"`
+
+## Files Changed
+
+- `js/src/session/compaction.ts` — Lower margin, add estimation fallback
+- `js/src/session/prompt.ts` — Pass estimated tokens, cap output tokens
+- `js/src/cli/defaults.ts` — Update default margin percentage
+- `rust/src/cli.rs` — Sync Rust default
+- `js/tests/compaction-model.test.ts` — Update tests, add estimation tests
+
+## References
+
+- [Issue #249](https://github.com/link-assistant/agent/issues/249)
+- [Solution draft log](./solution-draft-log.txt) — Full gist log from failed session
+- [Issue #217](https://github.com/link-assistant/agent/issues/217) — Original safety margin implementation
+- [Issue #219](https://github.com/link-assistant/agent/issues/219) — Separate compaction model
+- [Context Compaction Research](https://gist.github.com/badlogic/cd2ef65b0697c4dbe2d13fbecb0a0a5f) — Cross-tool comparison
+- [OpenCode compaction threshold](https://deepwiki.com/sst/opencode/2.4-context-management-and-compaction) — 75% default
+- [Gemini CLI compaction](https://wasnotwas.com/writing/context-compaction/) — 50% default

--- a/docs/case-studies/issue-249/README.md
+++ b/docs/case-studies/issue-249/README.md
@@ -36,6 +36,7 @@ The raw HTTP response body stream was captured by `verbose-fetch.ts` and clearly
 shows the SSE chunk with `"prompt_tokens":15506,"completion_tokens":80`.
 
 **Why does this happen?** The AI SDK `@ai-sdk/openai-compatible` v1.0.33 should:
+
 1. Parse the SSE chunk's `usage.prompt_tokens` → `usage.promptTokens`
 2. Emit finish event with `inputTokens: usage.promptTokens`
 3. AI SDK core converts via `convertV2UsageToV3` → `{inputTokens: {total: N}}`
@@ -57,6 +58,7 @@ computed `currentTokens = 0 + 0 + 0 = 0`, which is always below any
 `safeLimit`, so compaction was never triggered.
 
 **Evidence from logs:**
+
 ```
 "currentTokens": 0,
 "tokensBreakdown": { "input": 0, "cacheRead": 0, "output": 0 },
@@ -71,6 +73,7 @@ all 10+ checks showed `currentTokens: 0`.
 
 The system always requested `max_tokens: 32000` regardless of how much input
 was in the prompt. When input grew to 230,145 tokens:
+
 - Available: 262,144 - 230,145 = 31,999 tokens
 - Requested: 32,000 tokens
 - Total: 262,145 > 262,144 → **error**
@@ -82,14 +85,14 @@ counts. When they don't, a larger margin is needed as a safety buffer.
 
 ## Research: Industry Compaction Thresholds
 
-| Tool | Threshold | Margin | Notes |
-|------|-----------|--------|-------|
-| Gemini CLI | 50% | 50% | Most conservative; configurable |
-| OpenCode (upstream sst/opencode) | 75% | 25% | Hardcoded 0.75 |
-| Claude Code | ~83.5% | ~16.5% | Reduced buffer in 2026 |
-| Codex CLI | ~95% | ~5% | Users report "too late" |
-| link-assistant/agent (before) | 85% | 15% | |
-| link-assistant/agent (after) | 75% | 25% | Matches OpenCode upstream |
+| Tool                             | Threshold | Margin | Notes                           |
+| -------------------------------- | --------- | ------ | ------------------------------- |
+| Gemini CLI                       | 50%       | 50%    | Most conservative; configurable |
+| OpenCode (upstream sst/opencode) | 75%       | 25%    | Hardcoded 0.75                  |
+| Claude Code                      | ~83.5%    | ~16.5% | Reduced buffer in 2026          |
+| Codex CLI                        | ~95%      | ~5%    | Users report "too late"         |
+| link-assistant/agent (before)    | 85%       | 15%    |                                 |
+| link-assistant/agent (after)     | 75%       | 25%    | Matches OpenCode upstream       |
 
 **Community consensus:** 80-90% is the recommended range, with 85-90% as the
 sweet spot when token counting is reliable. When token counting is unreliable
@@ -112,6 +115,7 @@ available, falling back to a character-based heuristic (~4 chars/token) for
 models with unknown tokenizers.
 
 **Why not always use real BPE?** Different LLM providers use different tokenizers:
+
 - OpenAI models (GPT-4o, GPT-4.1, GPT-5): `o200k_base` BPE — supported via `gpt-tokenizer`
 - Nvidia Nemotron: Custom SentencePiece BPE (256K vocab) — no JS library available
 - Google Gemini: SentencePiece — no JS library available
@@ -157,11 +161,63 @@ OpenRouter SSE response showing valid `prompt_tokens: 15506` despite the AI SDK
 reporting 0 tokens at the step-finish level.
 
 **Additional diagnostic logging added in this PR:**
+
 - `processor.ts`: Step-finish raw usage diagnostics (verbose mode) — logs both
   the AI SDK's parsed usage and the raw `value.usage` from the finish-step event
 - `processor.ts`: Enhanced zero-token warning — now fires regardless of
   finishReason, with a hint pointing to verbose HTTP logs for the raw response
 - `session/index.ts`: `getUsage()` already logs raw usage data in verbose mode
+
+### Fix 4: Raw SSE usage recovery (AI SDK bypass)
+
+Added `SSEUsageExtractor` that intercepts raw HTTP SSE streaming responses at
+the `fetch()` level (before the AI SDK processes them) and parses usage tokens
+directly from SSE `data:` chunks. This works in both verbose and non-verbose
+modes. When the AI SDK's `finish-step` event reports zero tokens, the processor
+automatically recovers usage from the raw SSE data.
+
+This is modeled after OpenAI Codex's approach (Rust, raw HTTP + manual SSE
+parsing) and provides a reliable fallback regardless of AI SDK bugs.
+
+Supported SSE usage formats:
+
+- OpenAI: `usage.prompt_tokens`, `usage.completion_tokens`
+- Anthropic: `usage.input_tokens`, `usage.output_tokens`, `usage.cache_read_input_tokens`
+- Groq: `x_groq.usage.prompt_tokens`
+- Generic: `usage.promptTokens`, `usage.completionTokens`
+
+## Research: SDK Choices of Agentic CLIs
+
+| Tool            | Language   | SDK                     | Usage Source                           |
+| --------------- | ---------- | ----------------------- | -------------------------------------- |
+| **OpenCode**    | TypeScript | Vercel AI SDK (`ai` v6) | `streamText` usage — same bug exposure |
+| **Codex**       | Rust       | Custom (reqwest + SSE)  | Hand-parsed SSE events — most reliable |
+| **Gemini CLI**  | TypeScript | `@google/genai` v1.30   | `usageMetadata` from SDK               |
+| **Qwen Agent**  | Python     | `dashscope` + `openai`  | SDK response objects                   |
+| **Claude Code** | TypeScript | `@anthropic-ai/sdk`     | Messages API usage field               |
+| **Aider**       | Python     | `litellm` v1.82         | `completion.usage` via litellm         |
+
+**Key findings:**
+
+- The Vercel AI SDK streaming usage bug is a **known open issue** (vercel/ai #9921, #12477, #7412)
+- `@ai-sdk/openai-compatible` has been updated from v1.x to v2.x — may fix some issues
+- OpenCode uses the exact same AI SDK pattern and would have the same vulnerability
+- Codex is the only tool that parses raw HTTP, making it immune to SDK abstraction bugs
+- Our SSE usage recovery provides Codex-like reliability while keeping the AI SDK abstraction
+
+**Future work: Switchable SDK backends**
+
+The user requested the ability to switch between SDK backends via CLI option.
+Full backend alternatives that could be implemented:
+
+1. **AI SDK (current)** — `streamText()` + `generateText()` via Vercel AI SDK
+2. **Direct fetch** — Raw HTTP + SSE parsing (like Codex), bypassing AI SDK entirely
+3. **Provider-specific SDKs** — `@anthropic-ai/sdk`, `@google/genai`, OpenAI SDK
+4. **LiteLLM** — Universal gateway (Python ecosystem, requires bridge)
+
+This would require significant architectural work (abstracting the provider layer,
+implementing SSE parsing for each format, tool call handling, etc.) and is tracked
+as a separate feature request.
 
 ## Upstream Issue Recommendations
 
@@ -182,13 +238,16 @@ reports 0 for all token counts. This should be reported to `vercel/ai` with:
 ## Files Changed
 
 - `js/src/util/token.ts` — Add `countTokens()` with real BPE via gpt-tokenizer, heuristic fallback
+- `js/src/util/sse-usage-extractor.ts` — Raw SSE stream usage parser (AI SDK bypass)
 - `js/src/session/compaction.ts` — Lower margin, add estimation fallback
 - `js/src/session/prompt.ts` — Use `Token.countTokens()` for overflow detection, cap output tokens
-- `js/src/session/processor.ts` — Enhanced zero-token diagnostics and verbose logging
+- `js/src/session/processor.ts` — SSE usage recovery + enhanced zero-token diagnostics
+- `js/src/provider/provider.ts` — SSE stream interception for usage extraction
 - `js/src/cli/defaults.ts` — Update default margin percentage
 - `rust/src/cli.rs` — Sync Rust default
 - `js/tests/compaction-model.test.ts` — Update tests, add estimation tests
 - `js/tests/token.test.ts` — Tests for Token.estimate and Token.countTokens
+- `js/tests/sse-usage-extractor.test.ts` — 17 tests for SSE usage extraction
 
 ## References
 

--- a/docs/case-studies/issue-249/README.md
+++ b/docs/case-studies/issue-249/README.md
@@ -9,12 +9,52 @@ returned 0 for all token counts.
 
 ## Root Causes
 
-### 1. Provider returns 0 token counts
+### 1. AI SDK fails to propagate token usage from raw HTTP response
 
-The Nvidia/nemotron provider (via OpenCode) returned 0 for `inputTokens`,
-`outputTokens`, and all other usage fields. The `isOverflow()` function computed
-`currentTokens = 0 + 0 + 0 = 0`, which is always below any `safeLimit`,
-so compaction was never triggered.
+**Deep investigation revealed the provider DOES return valid usage data** in the
+raw HTTP SSE stream. The final streaming chunk from OpenRouter contains:
+
+```json
+"usage": {
+  "prompt_tokens": 15506,
+  "completion_tokens": 80,
+  "total_tokens": 15586,
+  "completion_tokens_details": { "reasoning_tokens": 19 }
+}
+```
+
+However, the AI SDK's `@ai-sdk/openai-compatible` v1.0.33 fails to propagate
+these values to the `finish-step` event. The `step-finish` event consistently
+shows all zeros:
+
+```json
+"tokens": { "input": 0, "output": 0, "reasoning": 0, "cache": { "read": 0, "write": 0 } }
+```
+
+**Evidence from verbose HTTP logs (line 2663 of original-failure-log.txt):**
+The raw HTTP response body stream was captured by `verbose-fetch.ts` and clearly
+shows the SSE chunk with `"prompt_tokens":15506,"completion_tokens":80`.
+
+**Why does this happen?** The AI SDK `@ai-sdk/openai-compatible` v1.0.33 should:
+1. Parse the SSE chunk's `usage.prompt_tokens` → `usage.promptTokens`
+2. Emit finish event with `inputTokens: usage.promptTokens`
+3. AI SDK core converts via `convertV2UsageToV3` → `{inputTokens: {total: N}}`
+4. `asLanguageModelUsage` reads `usage.inputTokens.total`
+
+The exact point of failure in steps 1-4 is within the AI SDK internals and
+difficult to isolate without a dedicated reproducer. The schema, SSE parsing,
+and mapping code all appear correct on inspection. A potential cause is a
+race condition in stream processing, or an incompatibility between
+`@ai-sdk/openai-compatible` v1.0.33 and `ai` v6.0.1.
+
+**This is an upstream AI SDK issue** that should be reported to the Vercel AI
+SDK repository with a reproducible example using OpenRouter + streaming.
+
+### 1b. Overflow detection used only provider-reported tokens (no fallback)
+
+Because the step-finish event showed 0 tokens, the `isOverflow()` function
+computed `currentTokens = 0 + 0 + 0 = 0`, which is always below any
+`safeLimit`, so compaction was never triggered.
 
 **Evidence from logs:**
 ```
@@ -92,17 +132,59 @@ model's hard limit.
 
 ## Timeline
 
-1. Session starts with `nemotron-3-super-free` (context: 262,144)
-2. Multiple turns execute; overflow checks all show `currentTokens: 0`
-3. Input grows to 230,145 tokens (estimated ~920,580 characters)
-4. Request sent with `max_tokens: 32000` → total 262,145 > 262,144
-5. Nvidia returns: `"This model's maximum context length is 262144 tokens"`
+1. Session starts with `nemotron-3-super-free` (context: 262,144) via OpenCode/OpenRouter
+2. Request is sent with `"stream": true, "stream_options": {"include_usage": true}`
+3. OpenRouter returns valid SSE stream with `prompt_tokens: 15506, completion_tokens: 80`
+4. AI SDK `@ai-sdk/openai-compatible` receives the stream but reports 0 tokens in finish-step
+5. `isOverflow()` computes `currentTokens = 0`, compaction never triggers
+6. Multiple turns execute; this pattern repeats 10+ times with growing context
+7. Input grows to 230,145 tokens (estimated ~920,580 characters)
+8. Request sent with `max_tokens: 32000` → total 262,145 > 262,144
+9. Nvidia returns: `"This model's maximum context length is 262144 tokens"`
+
+## Raw Request/Response Logging
+
+The codebase already has comprehensive HTTP request/response logging via
+`verbose-fetch.ts` (enabled with `--verbose` flag). This logs:
+
+- **Request**: method, URL, sanitized headers, body preview
+- **Response**: status, headers, duration, body preview
+- **Streaming responses**: Full SSE stream body captured via `response.body.tee()`
+- **Errors**: Stack traces, error cause chains
+
+This logging **proved essential** for this investigation — it captured the raw
+OpenRouter SSE response showing valid `prompt_tokens: 15506` despite the AI SDK
+reporting 0 tokens at the step-finish level.
+
+**Additional diagnostic logging added in this PR:**
+- `processor.ts`: Step-finish raw usage diagnostics (verbose mode) — logs both
+  the AI SDK's parsed usage and the raw `value.usage` from the finish-step event
+- `processor.ts`: Enhanced zero-token warning — now fires regardless of
+  finishReason, with a hint pointing to verbose HTTP logs for the raw response
+- `session/index.ts`: `getUsage()` already logs raw usage data in verbose mode
+
+## Upstream Issue Recommendations
+
+### Vercel AI SDK: `@ai-sdk/openai-compatible` streaming usage not propagated
+
+The raw HTTP response from OpenRouter contains valid `prompt_tokens` and
+`completion_tokens` in the final SSE chunk, but the AI SDK's step-finish event
+reports 0 for all token counts. This should be reported to `vercel/ai` with:
+
+- **Steps to reproduce**: Use `@ai-sdk/openai-compatible` v1.0.33 + `ai` v6.0.1,
+  call `streamText()` with an OpenRouter endpoint that proxies to a free-tier
+  model (e.g., `nvidia/nemotron-3-super-free`)
+- **Expected**: `onStepFinish` usage reflects the provider's usage from the SSE stream
+- **Actual**: All token counts are 0
+- **Evidence**: Raw HTTP response captured by verbose-fetch shows valid usage data
+- **Workaround**: Token estimation fallback + lower safety margin (this PR)
 
 ## Files Changed
 
 - `js/src/util/token.ts` — Add `countTokens()` with real BPE via gpt-tokenizer, heuristic fallback
 - `js/src/session/compaction.ts` — Lower margin, add estimation fallback
 - `js/src/session/prompt.ts` — Use `Token.countTokens()` for overflow detection, cap output tokens
+- `js/src/session/processor.ts` — Enhanced zero-token diagnostics and verbose logging
 - `js/src/cli/defaults.ts` — Update default margin percentage
 - `rust/src/cli.rs` — Sync Rust default
 - `js/tests/compaction-model.test.ts` — Update tests, add estimation tests

--- a/js/.changeset/lower-compaction-threshold.md
+++ b/js/.changeset/lower-compaction-threshold.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/agent': patch
+---
+
+Lower compaction safety margin from 85% to 75% to reduce context overflow errors. Add token estimation fallback when providers return 0 token counts. Cap maxOutputTokens to never exceed model context limit.

--- a/js/bun.lock
+++ b/js/bun.lock
@@ -43,6 +43,7 @@
         "diff": "^8.0.2",
         "fuzzysort": "^3.1.0",
         "glob": "^10.0.0",
+        "gpt-tokenizer": "^3.4.0",
         "gray-matter": "^4.0.3",
         "hono": "^4.10.6",
         "hono-openapi": "^1.1.1",
@@ -797,6 +798,8 @@
     "google-logging-utils": ["google-logging-utils@1.1.3", "", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gpt-tokenizer": ["gpt-tokenizer@3.4.0", "", {}, "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 

--- a/js/package.json
+++ b/js/package.json
@@ -90,6 +90,7 @@
     "diff": "^8.0.2",
     "fuzzysort": "^3.1.0",
     "glob": "^10.0.0",
+    "gpt-tokenizer": "^3.4.0",
     "gray-matter": "^4.0.3",
     "hono": "^4.10.6",
     "hono-openapi": "^1.1.1",

--- a/js/src/cli/defaults.ts
+++ b/js/src/cli/defaults.ts
@@ -52,6 +52,11 @@ export const DEFAULT_COMPACTION_MODELS =
  * Applied only when the compaction model has a context window equal to or smaller
  * than the base model. When the compaction model has a larger context, the margin
  * is automatically set to 0 (allowing 100% context usage).
+ *
+ * Increased from 15% to 25% to reduce probability of context overflow errors,
+ * especially when providers return inaccurate or zero token counts.
+ * Matches OpenCode upstream's 75% threshold (25% margin).
  * @see https://github.com/link-assistant/agent/issues/219
+ * @see https://github.com/link-assistant/agent/issues/249
  */
-export const DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT = 15;
+export const DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT = 25;

--- a/js/src/provider/provider.ts
+++ b/js/src/provider/provider.ts
@@ -17,6 +17,7 @@ import { iife } from '../util/iife';
 import { createEchoModel } from './echo';
 import { createCacheModel } from './cache';
 import { RetryFetch } from './retry-fetch';
+import { SSEUsageExtractor } from '../util/sse-usage-extractor';
 
 // Direct imports for bundled providers - these are pre-installed to avoid runtime installation hangs
 // @see https://github.com/link-assistant/agent/issues/173
@@ -1232,8 +1233,41 @@ export namespace Provider {
           // flag state loss in subprocess/module-reload scenarios.
           // See: https://github.com/link-assistant/agent/issues/206
           // See: https://github.com/link-assistant/agent/issues/227
+          // Even when verbose mode is off, intercept streaming responses
+          // to extract usage tokens from raw SSE data. This is critical for
+          // recovering usage when the AI SDK drops it from finish-step events.
+          // @see https://github.com/link-assistant/agent/issues/249
           if (!isVerbose()) {
-            return innerFetch(input, init);
+            const response = await innerFetch(input, init);
+            const ct = response.headers.get('content-type') ?? '';
+            const isSSE =
+              ct.includes('event-stream') || ct.includes('octet-stream');
+            if (isSSE && response.body) {
+              const [sdkStream, usageStream] = response.body.tee();
+              const sseReqId = SSEUsageExtractor.nextRequestId();
+              (async () => {
+                try {
+                  const reader = usageStream.getReader();
+                  const decoder = new TextDecoder();
+                  let body = '';
+                  while (true) {
+                    const { done, value } = await reader.read();
+                    if (done) break;
+                    body += decoder.decode(value, { stream: true });
+                    if (body.length > 50000) break;
+                  }
+                  SSEUsageExtractor.processStreamForUsage(sseReqId, body);
+                } catch {
+                  // Never break the SDK stream
+                }
+              })();
+              return new Response(sdkStream, {
+                status: response.status,
+                statusText: response.statusText,
+                headers: response.headers,
+              });
+            }
+            return response;
           }
 
           httpCallCount++;
@@ -1374,6 +1408,10 @@ export namespace Provider {
                 const [sdkStream, logStream] = response.body.tee();
 
                 // Consume log stream asynchronously (does not block SDK)
+                // Also extract usage tokens from raw SSE data as fallback
+                // for when the AI SDK drops usage from its finish-step event.
+                // @see https://github.com/link-assistant/agent/issues/249
+                const sseRequestId = SSEUsageExtractor.nextRequestId();
                 (async () => {
                   try {
                     const reader = logStream.getReader();
@@ -1395,6 +1433,11 @@ export namespace Provider {
                         }
                       }
                     }
+                    // Extract usage from raw SSE stream as AI SDK fallback
+                    SSEUsageExtractor.processStreamForUsage(
+                      sseRequestId,
+                      bodyPreview
+                    );
                     // Use direct (non-lazy) logging for stream body
                     // See: https://github.com/link-assistant/agent/issues/211
                     log.info('HTTP response body (stream)', {
@@ -1402,6 +1445,7 @@ export namespace Provider {
                       providerID: provider.id,
                       callNum,
                       url,
+                      sseRequestId,
                       bodyPreview: truncated
                         ? bodyPreview + `... [truncated]`
                         : bodyPreview,

--- a/js/src/session/compaction.ts
+++ b/js/src/session/compaction.ts
@@ -30,11 +30,19 @@ export namespace SessionCompaction {
 
   /**
    * Default safety margin ratio for compaction trigger.
-   * We trigger compaction at 85% of usable context to avoid hitting hard limits.
-   * This means we stop 15% before (context - output) tokens.
+   * We trigger compaction at 75% of usable context to avoid hitting hard limits.
+   * This means we stop 25% before (context - output) tokens.
+   *
+   * Lowered from 0.85 to 0.75 (matching OpenCode upstream) because:
+   * - When providers return 0 token counts, the system relies on estimated tokens
+   *   which can be inaccurate, so a larger safety buffer is needed.
+   * - Gemini CLI uses 50%, OpenCode upstream uses 75%, Claude Code uses ~83.5%.
+   * - A 75% threshold provides a good balance between context utilization and
+   *   preventing context overflow errors.
    * @see https://github.com/link-assistant/agent/issues/217
+   * @see https://github.com/link-assistant/agent/issues/249
    */
-  export const OVERFLOW_SAFETY_MARGIN = 0.85;
+  export const OVERFLOW_SAFETY_MARGIN = 0.75;
 
   /**
    * A single compaction model entry in the cascade.

--- a/js/src/session/compaction.ts
+++ b/js/src/session/compaction.ts
@@ -169,7 +169,8 @@ export namespace SessionCompaction {
       currentTokens: count,
       providerTokens: providerCount,
       estimatedInputTokens: input.estimatedInputTokens ?? 0,
-      usingEstimate: providerCount === 0 && (input.estimatedInputTokens ?? 0) > 0,
+      usingEstimate:
+        providerCount === 0 && (input.estimatedInputTokens ?? 0) > 0,
       tokensBreakdown: {
         input: input.tokens.input,
         cacheRead: input.tokens.cache.read,

--- a/js/src/session/compaction.ts
+++ b/js/src/session/compaction.ts
@@ -125,12 +125,26 @@ export namespace SessionCompaction {
     model: ModelsDev.Model;
     compactionModel?: CompactionModelConfig;
     compactionModelContextLimit?: number;
+    /**
+     * Optional estimated input tokens from message content.
+     * Used as fallback when provider returns 0 for all token counts.
+     * This prevents the system from never triggering compaction when
+     * providers don't report token usage.
+     * @see https://github.com/link-assistant/agent/issues/249
+     */
+    estimatedInputTokens?: number;
   }) {
     if (config.disableAutocompact) return false;
     const baseModelContextLimit = input.model.limit.context;
     if (baseModelContextLimit === 0) return false;
-    const count =
+    const providerCount =
       input.tokens.input + input.tokens.cache.read + input.tokens.output;
+    // When provider returns 0 for all token counts, use the estimated input tokens
+    // as a fallback. This prevents the system from never triggering compaction
+    // when providers (e.g., OpenCode with Nvidia/nemotron) don't report token usage.
+    // @see https://github.com/link-assistant/agent/issues/249
+    const count =
+      providerCount > 0 ? providerCount : (input.estimatedInputTokens ?? 0);
     const outputTokenLimit =
       Math.min(input.model.limit.output, SessionPrompt.OUTPUT_TOKEN_MAX) ||
       SessionPrompt.OUTPUT_TOKEN_MAX;
@@ -153,6 +167,9 @@ export namespace SessionCompaction {
       compactionModelID: input.compactionModel?.modelID,
       compactionModelContextLimit: input.compactionModelContextLimit,
       currentTokens: count,
+      providerTokens: providerCount,
+      estimatedInputTokens: input.estimatedInputTokens ?? 0,
+      usingEstimate: providerCount === 0 && (input.estimatedInputTokens ?? 0) > 0,
       tokensBreakdown: {
         input: input.tokens.input,
         cacheRead: input.tokens.cache.read,

--- a/js/src/session/processor.ts
+++ b/js/src/session/processor.ts
@@ -327,20 +327,46 @@ export namespace SessionProcessor {
                   input.assistantMessage.cost += usage.cost;
                   input.assistantMessage.tokens = usage.tokens;
 
-                  // Log warning when provider returns zero tokens (#198)
+                  // Log raw usage data at step level for debugging token parsing issues.
+                  // The AI SDK may drop token data between the raw HTTP response and the
+                  // finish-step event (e.g., @ai-sdk/openai-compatible may not propagate
+                  // usage from SSE stream chunks). This log helps detect such mismatches.
+                  // @see https://github.com/link-assistant/agent/issues/249
+                  if (isVerbose()) {
+                    log.debug(() => ({
+                      message: 'step-finish raw usage diagnostics',
+                      providerID: input.providerID,
+                      modelID: input.model.id,
+                      parsedTokens: usage.tokens,
+                      rawUsage: JSON.stringify(value.usage ?? null),
+                      rawProviderMetadata: JSON.stringify(
+                        value.providerMetadata ?? null
+                      ),
+                      rawFinishReason: String(
+                        value.finishReason ?? 'undefined'
+                      ),
+                      respondedModelID:
+                        (value as any).response?.modelId ?? 'none',
+                    }));
+                  }
+
+                  // Log warning when provider returns zero tokens (#198, #249)
+                  // This fires for any finish reason — not just 'unknown' — because the
+                  // root cause is the AI SDK not propagating usage from the raw HTTP
+                  // response, which can happen regardless of finish reason.
                   if (
                     usage.tokens.input === 0 &&
                     usage.tokens.output === 0 &&
-                    usage.tokens.reasoning === 0 &&
-                    finishReason === 'unknown'
+                    usage.tokens.reasoning === 0
                   ) {
                     log.warn(() => ({
                       message:
-                        'provider returned zero tokens with unknown finish reason at step level',
+                        'provider returned zero tokens at step level — AI SDK may not be propagating usage from raw HTTP response',
                       providerID: input.providerID,
                       requestedModelID: input.model.id,
                       respondedModelID:
                         (value as any).response?.modelId ?? 'none',
+                      finishReason,
                       rawFinishReason: String(
                         value.finishReason ?? 'undefined'
                       ),
@@ -348,8 +374,9 @@ export namespace SessionProcessor {
                       providerMetadata: JSON.stringify(
                         value.providerMetadata ?? null
                       ),
+                      hint: 'Check verbose HTTP logs for raw provider response — the HTTP response may contain valid usage data that the AI SDK failed to propagate. The token estimation fallback in isOverflow() handles this case.',
                       issue:
-                        'https://github.com/link-assistant/agent/issues/198',
+                        'https://github.com/link-assistant/agent/issues/249',
                     }));
                   }
 

--- a/js/src/session/processor.ts
+++ b/js/src/session/processor.ts
@@ -18,6 +18,7 @@ import { SessionRetry } from './retry';
 import { SessionStatus } from './status';
 import { config, isVerbose } from '../config/config';
 import { SessionCompaction } from './compaction';
+import { SSEUsageExtractor } from '../util/sse-usage-extractor';
 
 export namespace SessionProcessor {
   const DOOM_LOOP_THRESHOLD = 3;
@@ -350,34 +351,70 @@ export namespace SessionProcessor {
                     }));
                   }
 
-                  // Log warning when provider returns zero tokens (#198, #249)
-                  // This fires for any finish reason — not just 'unknown' — because the
-                  // root cause is the AI SDK not propagating usage from the raw HTTP
-                  // response, which can happen regardless of finish reason.
+                  // When AI SDK returns zero tokens, try to recover usage from
+                  // raw SSE stream data captured by the fetch interceptor.
+                  // The AI SDK may drop token data between the raw HTTP response
+                  // and the finish-step event (known bug in @ai-sdk/openai-compatible).
+                  // @see https://github.com/link-assistant/agent/issues/249
                   if (
                     usage.tokens.input === 0 &&
                     usage.tokens.output === 0 &&
                     usage.tokens.reasoning === 0
                   ) {
-                    log.warn(() => ({
-                      message:
-                        'provider returned zero tokens at step level — AI SDK may not be propagating usage from raw HTTP response',
-                      providerID: input.providerID,
-                      requestedModelID: input.model.id,
-                      respondedModelID:
-                        (value as any).response?.modelId ?? 'none',
-                      finishReason,
-                      rawFinishReason: String(
-                        value.finishReason ?? 'undefined'
-                      ),
-                      rawUsage: JSON.stringify(value.usage ?? null),
-                      providerMetadata: JSON.stringify(
-                        value.providerMetadata ?? null
-                      ),
-                      hint: 'Check verbose HTTP logs for raw provider response — the HTTP response may contain valid usage data that the AI SDK failed to propagate. The token estimation fallback in isOverflow() handles this case.',
-                      issue:
-                        'https://github.com/link-assistant/agent/issues/249',
-                    }));
+                    const sseUsage = SSEUsageExtractor.consumeLatestUsage();
+                    if (sseUsage) {
+                      const recoveredUsage = Session.getUsage({
+                        model: input.model,
+                        usage: {
+                          inputTokens: sseUsage.promptTokens,
+                          outputTokens: sseUsage.completionTokens,
+                          totalTokens: sseUsage.totalTokens,
+                          reasoningTokens: sseUsage.reasoningTokens ?? 0,
+                          cachedInputTokens: sseUsage.cachedTokens ?? 0,
+                        },
+                        metadata: value.providerMetadata,
+                      });
+                      input.assistantMessage.cost =
+                        input.assistantMessage.cost -
+                        usage.cost +
+                        recoveredUsage.cost;
+                      input.assistantMessage.tokens = recoveredUsage.tokens;
+                      log.warn(() => ({
+                        message:
+                          'recovered usage from raw SSE stream — AI SDK dropped token data',
+                        providerID: input.providerID,
+                        requestedModelID: input.model.id,
+                        recoveredTokens: recoveredUsage.tokens,
+                        recoveredCost: recoveredUsage.cost,
+                        ssePromptTokens: sseUsage.promptTokens,
+                        sseCompletionTokens: sseUsage.completionTokens,
+                        issue:
+                          'https://github.com/link-assistant/agent/issues/249',
+                      }));
+                      // Update the step-finish part with recovered data
+                      usage.tokens = recoveredUsage.tokens;
+                      usage.cost = recoveredUsage.cost;
+                    } else {
+                      log.warn(() => ({
+                        message:
+                          'provider returned zero tokens at step level — AI SDK may not be propagating usage from raw HTTP response',
+                        providerID: input.providerID,
+                        requestedModelID: input.model.id,
+                        respondedModelID:
+                          (value as any).response?.modelId ?? 'none',
+                        finishReason,
+                        rawFinishReason: String(
+                          value.finishReason ?? 'undefined'
+                        ),
+                        rawUsage: JSON.stringify(value.usage ?? null),
+                        providerMetadata: JSON.stringify(
+                          value.providerMetadata ?? null
+                        ),
+                        hint: 'No raw SSE usage found either. The token estimation fallback in isOverflow() handles this case.',
+                        issue:
+                          'https://github.com/link-assistant/agent/issues/249',
+                      }));
+                    }
                   }
 
                   // Build model info if --output-response-model flag is enabled

--- a/js/src/session/prompt.ts
+++ b/js/src/session/prompt.ts
@@ -667,6 +667,27 @@ export namespace SessionPrompt {
       }
 
       // context overflow, needs compaction
+      // Estimate input tokens from message content as fallback for providers
+      // that return 0 token counts (e.g., Nvidia/nemotron via OpenCode).
+      // @see https://github.com/link-assistant/agent/issues/249
+      const estimatedInputTokens = Token.estimate(
+        msgs
+          .map((m) =>
+            m.parts
+              .map((p) => {
+                if (p.type === 'text') return p.text;
+                if (
+                  p.type === 'tool' &&
+                  p.state.status === 'completed' &&
+                  !p.state.time.compacted
+                )
+                  return p.state.output;
+                return '';
+              })
+              .join('')
+          )
+          .join('')
+      );
       if (
         lastFinished &&
         lastFinished.summary !== true &&
@@ -675,6 +696,7 @@ export namespace SessionPrompt {
           model: model.info ?? { id: model.modelID },
           compactionModel: lastUser.compactionModel,
           compactionModelContextLimit,
+          estimatedInputTokens,
         })
       ) {
         await SessionCompaction.create({

--- a/js/src/session/prompt.ts
+++ b/js/src/session/prompt.ts
@@ -706,27 +706,29 @@ export namespace SessionPrompt {
       }
 
       // context overflow, needs compaction
-      // Estimate input tokens from message content as fallback for providers
+      // Count input tokens from message content as fallback for providers
       // that return 0 token counts (e.g., Nvidia/nemotron via OpenCode).
+      // Uses real BPE tokenization (gpt-tokenizer) when available, falls back
+      // to character-based heuristic (~4 chars/token) for unknown tokenizers.
       // @see https://github.com/link-assistant/agent/issues/249
-      const estimatedInputTokens = Token.estimate(
-        msgs
-          .map((m) =>
-            m.parts
-              .map((p) => {
-                if (p.type === 'text') return p.text;
-                if (
-                  p.type === 'tool' &&
-                  p.state.status === 'completed' &&
-                  !p.state.time.compacted
-                )
-                  return p.state.output;
-                return '';
-              })
-              .join('')
-          )
-          .join('')
-      );
+      const messageContent = msgs
+        .map((m) =>
+          m.parts
+            .map((p) => {
+              if (p.type === 'text') return p.text;
+              if (
+                p.type === 'tool' &&
+                p.state.status === 'completed' &&
+                !p.state.time.compacted
+              )
+                return p.state.output;
+              return '';
+            })
+            .join('')
+        )
+        .join('');
+      const tokenResult = Token.countTokens(messageContent);
+      const estimatedInputTokens = tokenResult.count;
       if (
         lastFinished &&
         lastFinished.summary !== true &&

--- a/js/src/session/prompt.ts
+++ b/js/src/session/prompt.ts
@@ -54,6 +54,46 @@ export namespace SessionPrompt {
   const log = Log.create({ service: 'session.prompt' });
   export const OUTPUT_TOKEN_MAX = 32_000;
 
+  /**
+   * Cap maxOutputTokens so that estimated input + output never exceeds
+   * the model's context limit. This prevents "context length exceeded" errors
+   * when the conversation has grown close to the model's limit.
+   *
+   * Returns at least 1024 tokens to avoid degenerate cases.
+   * Returns baseMaxOutput unchanged if contextLimit is 0 (unknown).
+   * @see https://github.com/link-assistant/agent/issues/249
+   */
+  function capOutputTokensToContext(input: {
+    baseMaxOutput: number;
+    contextLimit: number;
+    estimatedInputTokens: number;
+  }): number {
+    if (input.contextLimit <= 0) return input.baseMaxOutput;
+    const available = input.contextLimit - input.estimatedInputTokens;
+    if (available < 1024) {
+      log.warn(() => ({
+        message:
+          'estimated input tokens near or exceeding context limit — capping output to 1024',
+        contextLimit: input.contextLimit,
+        estimatedInputTokens: input.estimatedInputTokens,
+        available,
+      }));
+      return 1024;
+    }
+    const capped = Math.min(input.baseMaxOutput, available);
+    if (capped < input.baseMaxOutput) {
+      log.info(() => ({
+        message:
+          'capped maxOutputTokens to fit within context limit',
+        baseMaxOutput: input.baseMaxOutput,
+        cappedMaxOutput: capped,
+        contextLimit: input.contextLimit,
+        estimatedInputTokens: input.estimatedInputTokens,
+      }));
+    }
+    return capped;
+  }
+
   const state = Instance.state(
     () => {
       const data: Record<
@@ -930,12 +970,16 @@ export namespace SessionPrompt {
           // set to 0, we handle loop
           maxRetries: 0,
           activeTools: Object.keys(tools).filter((x) => x !== 'invalid'),
-          maxOutputTokens: ProviderTransform.maxOutputTokens(
-            model.providerID,
-            params.options,
-            model.info?.limit?.output ?? 100000,
-            OUTPUT_TOKEN_MAX
-          ),
+          maxOutputTokens: capOutputTokensToContext({
+            baseMaxOutput: ProviderTransform.maxOutputTokens(
+              model.providerID,
+              params.options,
+              model.info?.limit?.output ?? 100000,
+              OUTPUT_TOKEN_MAX
+            ),
+            contextLimit: model.info?.limit?.context ?? 0,
+            estimatedInputTokens,
+          }),
           abortSignal: abort,
           providerOptions: ProviderTransform.providerOptions(
             model.npm,

--- a/js/src/session/prompt.ts
+++ b/js/src/session/prompt.ts
@@ -83,8 +83,7 @@ export namespace SessionPrompt {
     const capped = Math.min(input.baseMaxOutput, available);
     if (capped < input.baseMaxOutput) {
       log.info(() => ({
-        message:
-          'capped maxOutputTokens to fit within context limit',
+        message: 'capped maxOutputTokens to fit within context limit',
         baseMaxOutput: input.baseMaxOutput,
         cappedMaxOutput: capped,
         contextLimit: input.contextLimit,

--- a/js/src/util/sse-usage-extractor.ts
+++ b/js/src/util/sse-usage-extractor.ts
@@ -1,0 +1,144 @@
+import { Log } from './log';
+import { isVerbose } from '../config/config';
+
+const log = Log.create({ service: 'sse-usage' });
+
+export interface SSEUsageData {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  cachedTokens?: number;
+  reasoningTokens?: number;
+  timestamp: number;
+}
+
+const pendingUsage = new Map<string, SSEUsageData>();
+let requestCounter = 0;
+
+export namespace SSEUsageExtractor {
+  export function nextRequestId(): string {
+    return `sse-req-${++requestCounter}`;
+  }
+
+  export function extractUsageFromSSEChunk(
+    chunk: string
+  ): SSEUsageData | undefined {
+    const lines = chunk.split('\n');
+    let lastUsage: SSEUsageData | undefined;
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      const data = line.slice(6).trim();
+      if (data === '[DONE]') continue;
+
+      try {
+        const parsed = JSON.parse(data);
+        const usage =
+          parsed.usage ?? parsed.x_groq?.usage ?? parsed.choices?.[0]?.usage;
+
+        if (usage && typeof usage === 'object') {
+          const prompt =
+            usage.prompt_tokens ?? usage.input_tokens ?? usage.promptTokens;
+          const completion =
+            usage.completion_tokens ??
+            usage.output_tokens ??
+            usage.completionTokens;
+          const total =
+            usage.total_tokens ?? usage.totalTokens ?? prompt + completion;
+
+          if (
+            typeof prompt === 'number' &&
+            typeof completion === 'number' &&
+            (prompt > 0 || completion > 0)
+          ) {
+            lastUsage = {
+              promptTokens: prompt,
+              completionTokens: completion,
+              totalTokens:
+                typeof total === 'number' ? total : prompt + completion,
+              cachedTokens:
+                usage.prompt_tokens_details?.cached_tokens ??
+                usage.cache_read_input_tokens ??
+                usage.cachedTokens ??
+                undefined,
+              reasoningTokens:
+                usage.completion_tokens_details?.reasoning_tokens ??
+                usage.reasoning_tokens ??
+                undefined,
+              timestamp: Date.now(),
+            };
+          }
+        }
+      } catch {
+        // Not valid JSON — skip
+      }
+    }
+
+    return lastUsage;
+  }
+
+  export function processStreamForUsage(
+    requestId: string,
+    streamBody: string
+  ): void {
+    const usage = extractUsageFromSSEChunk(streamBody);
+    if (usage) {
+      pendingUsage.set(requestId, usage);
+      if (isVerbose()) {
+        log.info('raw SSE usage extracted', {
+          requestId,
+          promptTokens: usage.promptTokens,
+          completionTokens: usage.completionTokens,
+          totalTokens: usage.totalTokens,
+          cachedTokens: usage.cachedTokens,
+          reasoningTokens: usage.reasoningTokens,
+        });
+      }
+    }
+  }
+
+  export function getUsage(requestId: string): SSEUsageData | undefined {
+    return pendingUsage.get(requestId);
+  }
+
+  export function consumeUsage(requestId: string): SSEUsageData | undefined {
+    const usage = pendingUsage.get(requestId);
+    if (usage) {
+      pendingUsage.delete(requestId);
+    }
+    return usage;
+  }
+
+  export function getLatestUsage(): SSEUsageData | undefined {
+    let latest: SSEUsageData | undefined;
+    for (const usage of pendingUsage.values()) {
+      if (!latest || usage.timestamp > latest.timestamp) {
+        latest = usage;
+      }
+    }
+    return latest;
+  }
+
+  export function consumeLatestUsage(): SSEUsageData | undefined {
+    let latestKey: string | undefined;
+    let latestUsage: SSEUsageData | undefined;
+    for (const [key, usage] of pendingUsage.entries()) {
+      if (!latestUsage || usage.timestamp > latestUsage.timestamp) {
+        latestKey = key;
+        latestUsage = usage;
+      }
+    }
+    if (latestKey) {
+      pendingUsage.delete(latestKey);
+    }
+    return latestUsage;
+  }
+
+  export function clear(): void {
+    pendingUsage.clear();
+  }
+
+  export function size(): number {
+    return pendingUsage.size;
+  }
+}

--- a/js/src/util/token.ts
+++ b/js/src/util/token.ts
@@ -1,7 +1,97 @@
+import { Log } from './log';
+
+/**
+ * Token estimation utilities.
+ *
+ * Provides two levels of accuracy:
+ *
+ * 1. **Real BPE tokenization** via `gpt-tokenizer` (o200k_base encoding) —
+ *    accurate for OpenAI-compatible models (GPT-4o, GPT-4.1, GPT-5, etc.).
+ *    Used by `countTokens()` when available.
+ *
+ * 2. **Character-based heuristic** (≈4 chars per token for English text) —
+ *    fallback for models with unknown tokenizers (Nvidia Nemotron, Google Gemini,
+ *    Meta Llama, etc.). Their tokenizers use custom SentencePiece BPE vocabularies
+ *    that are not available as JS libraries.
+ *
+ * For compaction/overflow decisions, the heuristic is sufficient because:
+ * - The 75% safety margin (25% buffer) absorbs estimation inaccuracy
+ * - The `capOutputTokensToContext` function caps output tokens as a last defense
+ * - Even real tokenizers would be wrong for non-OpenAI models
+ *
+ * @see https://github.com/link-assistant/agent/issues/249
+ */
 export namespace Token {
+  const log = Log.create({ service: 'token' });
+
+  /** Default characters-per-token ratio for the heuristic estimator. */
   const CHARS_PER_TOKEN = 4;
 
+  /**
+   * Heuristic token estimation based on character count.
+   * Returns an approximate token count using the ~4 chars/token rule of thumb.
+   * This is accurate to within ±20% for typical English text across most LLM
+   * tokenizers (OpenAI, Nemotron, Llama, Gemini all average 3.5–4.5 chars/token
+   * for English).
+   */
   export function estimate(input: string) {
     return Math.max(0, Math.round((input || '').length / CHARS_PER_TOKEN));
+  }
+
+  /**
+   * Lazy-loaded BPE encoder instance. Uses o200k_base encoding (GPT-4o/GPT-4.1/GPT-5).
+   * Loaded on first call to `countTokens()`. Returns `null` if gpt-tokenizer is
+   * not available.
+   */
+  let _encoder: { encode: (text: string) => number[] } | null | undefined;
+
+  function getEncoder(): { encode: (text: string) => number[] } | null {
+    if (_encoder !== undefined) return _encoder;
+    try {
+      // Dynamic import to keep gpt-tokenizer optional.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('gpt-tokenizer/encoding/o200k_base');
+      _encoder = mod;
+      log.info(() => ({ message: 'loaded gpt-tokenizer (o200k_base)' }));
+      return _encoder;
+    } catch {
+      _encoder = null;
+      log.info(() => ({
+        message:
+          'gpt-tokenizer not available, using character-based estimation',
+      }));
+      return null;
+    }
+  }
+
+  /**
+   * Count tokens using real BPE tokenization when available, falling back to
+   * the character-based heuristic.
+   *
+   * Use this for critical paths where accuracy matters (overflow detection,
+   * output token capping). For logging or non-critical estimation, prefer
+   * the cheaper `estimate()`.
+   *
+   * @returns An object with the token count and whether real BPE was used.
+   */
+  export function countTokens(input: string): {
+    count: number;
+    precise: boolean;
+  } {
+    if (!input) return { count: 0, precise: true };
+    const encoder = getEncoder();
+    if (encoder) {
+      try {
+        const tokens = encoder.encode(input);
+        return { count: tokens.length, precise: true };
+      } catch (e) {
+        log.warn(() => ({
+          message: 'BPE encoding failed, falling back to estimate',
+          error: String(e),
+          inputLength: input.length,
+        }));
+      }
+    }
+    return { count: estimate(input), precise: false };
   }
 }

--- a/js/tests/compaction-model.test.ts
+++ b/js/tests/compaction-model.test.ts
@@ -9,8 +9,9 @@ import { test, expect, describe } from 'bun:test';
  * 1. When compaction model has larger context than base model → no safety margin (ratio 1.0)
  * 2. When compaction model is "same" → apply configured safety margin
  * 3. When compaction model has equal or smaller context → apply configured safety margin
- * 4. Default safety margin is 15% (ratio 0.85)
+ * 4. Default safety margin is 25% (ratio 0.75) — lowered from 15% in #249
  * 5. Safety margin is configurable via --compaction-safety-margin
+ * 6. When provider returns 0 tokens, estimatedInputTokens fallback is used
  *
  * @see https://github.com/link-assistant/agent/issues/219
  */
@@ -19,11 +20,11 @@ import { test, expect, describe } from 'bun:test';
 import { SessionCompaction } from '../src/session/compaction';
 
 describe('computeSafetyMarginRatio', () => {
-  test('returns default 0.85 when no compaction model config', () => {
+  test('returns default 0.75 when no compaction model config', () => {
     const ratio = SessionCompaction.computeSafetyMarginRatio({
       baseModelContextLimit: 200_000,
     });
-    expect(ratio).toBe(0.85);
+    expect(ratio).toBe(0.75);
   });
 
   test('returns 1.0 when compaction model has larger context than base model', () => {
@@ -47,11 +48,11 @@ describe('computeSafetyMarginRatio', () => {
         providerID: 'opencode',
         modelID: 'some-model',
         useSameModel: false,
-        compactionSafetyMarginPercent: 15,
+        compactionSafetyMarginPercent: 25,
       },
       compactionModelContextLimit: 200_000,
     });
-    expect(ratio).toBe(0.85);
+    expect(ratio).toBe(0.75);
   });
 
   test('returns configured ratio when compaction model has smaller context', () => {
@@ -77,11 +78,11 @@ describe('computeSafetyMarginRatio', () => {
         providerID: 'opencode',
         modelID: 'minimax-m2.5-free',
         useSameModel: true,
-        compactionSafetyMarginPercent: 15,
+        compactionSafetyMarginPercent: 25,
       },
       compactionModelContextLimit: 400_000,
     });
-    expect(ratio).toBe(0.85);
+    expect(ratio).toBe(0.75);
   });
 
   test('supports custom safety margin percentage', () => {
@@ -117,11 +118,11 @@ describe('computeSafetyMarginRatio', () => {
         providerID: 'opencode',
         modelID: 'gpt-5-nano',
         useSameModel: false,
-        compactionSafetyMarginPercent: 15,
+        compactionSafetyMarginPercent: 25,
       },
       compactionModelContextLimit: 0,
     });
-    expect(ratio).toBe(0.85);
+    expect(ratio).toBe(0.75);
   });
 
   test('falls back to configured ratio when compaction model context limit is undefined', () => {
@@ -131,10 +132,10 @@ describe('computeSafetyMarginRatio', () => {
         providerID: 'opencode',
         modelID: 'gpt-5-nano',
         useSameModel: false,
-        compactionSafetyMarginPercent: 15,
+        compactionSafetyMarginPercent: 25,
       },
     });
-    expect(ratio).toBe(0.85);
+    expect(ratio).toBe(0.75);
   });
 });
 
@@ -159,10 +160,10 @@ describe('isOverflow with compaction model', () => {
     cache: { read: 0, write: 0 },
   };
 
-  test('overflows with default safety margin at 85% of usable context', () => {
+  test('overflows with default safety margin at 75% of usable context', () => {
     // usable = 200000 - 32000 = 168000
-    // safeLimit = 168000 * 0.85 = 142800
-    // tokens = 140000 + 0 + 5000 = 145000 > 142800 → overflow
+    // safeLimit = 168000 * 0.75 = 126000
+    // tokens = 140000 + 0 + 5000 = 145000 > 126000 → overflow
     const overflow = SessionCompaction.isOverflow({
       tokens,
       model: baseModel as any,
@@ -181,7 +182,7 @@ describe('isOverflow with compaction model', () => {
         providerID: 'opencode',
         modelID: 'gpt-5-nano',
         useSameModel: false,
-        compactionSafetyMarginPercent: 15,
+        compactionSafetyMarginPercent: 25,
       },
       compactionModelContextLimit: 400_000,
     });
@@ -200,11 +201,64 @@ describe('isOverflow with compaction model', () => {
         providerID: 'opencode',
         modelID: 'gpt-5-nano',
         useSameModel: false,
-        compactionSafetyMarginPercent: 15,
+        compactionSafetyMarginPercent: 25,
       },
       compactionModelContextLimit: 400_000,
     });
     expect(overflow).toBe(true);
+  });
+
+  test('uses estimatedInputTokens when provider returns 0 tokens', () => {
+    // When provider returns all zeros, use estimated tokens
+    // usable = 200000 - 32000 = 168000
+    // safeLimit = 168000 * 0.75 = 126000 (default ratio without compaction model)
+    // estimatedInputTokens = 130000 > 126000 → overflow
+    const zeroTokens = {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    };
+    const overflow = SessionCompaction.isOverflow({
+      tokens: zeroTokens,
+      model: baseModel as any,
+      estimatedInputTokens: 130_000,
+    });
+    expect(overflow).toBe(true);
+  });
+
+  test('does NOT use estimatedInputTokens when provider returns non-zero tokens', () => {
+    // When provider returns valid tokens, use them even if below threshold
+    // usable = 200000 - 32000 = 168000
+    // safeLimit = 168000 * 0.75 = 126000
+    // providerTokens = 50000 + 0 + 5000 = 55000 < 126000 → no overflow
+    // estimatedInputTokens = 200000 would cause overflow if used, but should be ignored
+    const lowTokens = {
+      input: 50_000,
+      output: 5_000,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    };
+    const overflow = SessionCompaction.isOverflow({
+      tokens: lowTokens,
+      model: baseModel as any,
+      estimatedInputTokens: 200_000,
+    });
+    expect(overflow).toBe(false);
+  });
+
+  test('does NOT overflow with 0 tokens and no estimate', () => {
+    const zeroTokens = {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    };
+    const overflow = SessionCompaction.isOverflow({
+      tokens: zeroTokens,
+      model: baseModel as any,
+    });
+    expect(overflow).toBe(false);
   });
 });
 
@@ -228,8 +282,8 @@ describe('contextDiagnostics with compaction model', () => {
       model: baseModel as any,
     });
     expect(diag).toBeDefined();
-    expect(diag!.safetyMargin).toBe(0.85);
-    expect(diag!.safeLimit).toBe(Math.floor(168_000 * 0.85));
+    expect(diag!.safetyMargin).toBe(0.75);
+    expect(diag!.safeLimit).toBe(Math.floor(168_000 * 0.75));
   });
 
   test('uses 1.0 ratio when compaction model has larger context', () => {
@@ -240,7 +294,7 @@ describe('contextDiagnostics with compaction model', () => {
         providerID: 'opencode',
         modelID: 'gpt-5-nano',
         useSameModel: false,
-        compactionSafetyMarginPercent: 15,
+        compactionSafetyMarginPercent: 25,
       },
       compactionModelContextLimit: 400_000,
     });
@@ -268,10 +322,10 @@ describe('CLI defaults', () => {
     );
   });
 
-  test('default compaction safety margin is 15%', async () => {
+  test('default compaction safety margin is 25%', async () => {
     const { DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT } =
       await import('../src/cli/defaults');
-    expect(DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT).toBe(15);
+    expect(DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT).toBe(25);
   });
 });
 
@@ -305,7 +359,7 @@ describe('CompactionModelConfig with cascade', () => {
       providerID: 'opencode',
       modelID: 'big-pickle',
       useSameModel: false,
-      compactionSafetyMarginPercent: 15,
+      compactionSafetyMarginPercent: 25,
       compactionModels: [
         { providerID: 'opencode', modelID: 'big-pickle', useSameModel: false },
         {
@@ -337,7 +391,7 @@ describe('CompactionModelConfig with cascade', () => {
       providerID: 'opencode',
       modelID: 'gpt-5-nano',
       useSameModel: false,
-      compactionSafetyMarginPercent: 15,
+      compactionSafetyMarginPercent: 25,
     };
     expect(config.compactionModels).toBeUndefined();
   });

--- a/js/tests/sse-usage-extractor.test.ts
+++ b/js/tests/sse-usage-extractor.test.ts
@@ -1,0 +1,168 @@
+import { describe, test, expect, beforeEach } from 'bun:test';
+import { SSEUsageExtractor } from '../src/util/sse-usage-extractor';
+
+describe('SSEUsageExtractor', () => {
+  beforeEach(() => {
+    SSEUsageExtractor.clear();
+  });
+
+  describe('extractUsageFromSSEChunk', () => {
+    test('extracts OpenAI-format usage from SSE data', () => {
+      const chunk = `data: {"id":"chatcmpl-123","choices":[],"usage":{"prompt_tokens":1500,"completion_tokens":80,"total_tokens":1580}}\n\ndata: [DONE]\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.promptTokens).toBe(1500);
+      expect(result!.completionTokens).toBe(80);
+      expect(result!.totalTokens).toBe(1580);
+    });
+
+    test('extracts Anthropic-format usage (input_tokens/output_tokens)', () => {
+      const chunk = `data: {"type":"message_delta","usage":{"input_tokens":2000,"output_tokens":150}}\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.promptTokens).toBe(2000);
+      expect(result!.completionTokens).toBe(150);
+    });
+
+    test('extracts cached tokens from prompt_tokens_details', () => {
+      const chunk = `data: {"usage":{"prompt_tokens":5000,"completion_tokens":200,"total_tokens":5200,"prompt_tokens_details":{"cached_tokens":3000}}}\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.cachedTokens).toBe(3000);
+    });
+
+    test('extracts reasoning tokens from completion_tokens_details', () => {
+      const chunk = `data: {"usage":{"prompt_tokens":1000,"completion_tokens":500,"total_tokens":1500,"completion_tokens_details":{"reasoning_tokens":300}}}\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.reasoningTokens).toBe(300);
+    });
+
+    test('extracts Anthropic cache_read_input_tokens', () => {
+      const chunk = `data: {"usage":{"input_tokens":4000,"output_tokens":100,"cache_read_input_tokens":2500}}\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.cachedTokens).toBe(2500);
+    });
+
+    test('returns last usage when multiple SSE events contain usage', () => {
+      const chunk = [
+        `data: {"usage":{"prompt_tokens":100,"completion_tokens":10,"total_tokens":110}}`,
+        ``,
+        `data: {"usage":{"prompt_tokens":200,"completion_tokens":20,"total_tokens":220}}`,
+        ``,
+        `data: [DONE]`,
+        ``,
+      ].join('\n');
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.promptTokens).toBe(200);
+      expect(result!.completionTokens).toBe(20);
+    });
+
+    test('returns undefined for SSE data without usage', () => {
+      const chunk = `data: {"id":"chatcmpl-123","choices":[{"delta":{"content":"Hello"}}]}\n\ndata: [DONE]\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeUndefined();
+    });
+
+    test('returns undefined for empty input', () => {
+      expect(SSEUsageExtractor.extractUsageFromSSEChunk('')).toBeUndefined();
+    });
+
+    test('returns undefined for usage with all zeros', () => {
+      const chunk = `data: {"usage":{"prompt_tokens":0,"completion_tokens":0,"total_tokens":0}}\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeUndefined();
+    });
+
+    test('handles malformed JSON gracefully', () => {
+      const chunk = `data: {invalid json}\ndata: {"usage":{"prompt_tokens":500,"completion_tokens":50,"total_tokens":550}}\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.promptTokens).toBe(500);
+    });
+
+    test('extracts Groq-format usage from x_groq field', () => {
+      const chunk = `data: {"x_groq":{"usage":{"prompt_tokens":800,"completion_tokens":100,"total_tokens":900}}}\n\n`;
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(chunk);
+      expect(result).toBeDefined();
+      expect(result!.promptTokens).toBe(800);
+      expect(result!.completionTokens).toBe(100);
+    });
+  });
+
+  describe('processStreamForUsage / consumeUsage', () => {
+    test('stores and retrieves usage by request ID', () => {
+      const id = SSEUsageExtractor.nextRequestId();
+      SSEUsageExtractor.processStreamForUsage(
+        id,
+        `data: {"usage":{"prompt_tokens":1000,"completion_tokens":50,"total_tokens":1050}}\n\n`
+      );
+      const usage = SSEUsageExtractor.getUsage(id);
+      expect(usage).toBeDefined();
+      expect(usage!.promptTokens).toBe(1000);
+    });
+
+    test('consumeUsage removes the entry', () => {
+      const id = SSEUsageExtractor.nextRequestId();
+      SSEUsageExtractor.processStreamForUsage(
+        id,
+        `data: {"usage":{"prompt_tokens":1000,"completion_tokens":50,"total_tokens":1050}}\n\n`
+      );
+      const usage = SSEUsageExtractor.consumeUsage(id);
+      expect(usage).toBeDefined();
+      expect(SSEUsageExtractor.getUsage(id)).toBeUndefined();
+    });
+
+    test('does not store when no usage found in stream', () => {
+      const id = SSEUsageExtractor.nextRequestId();
+      SSEUsageExtractor.processStreamForUsage(
+        id,
+        `data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n`
+      );
+      expect(SSEUsageExtractor.getUsage(id)).toBeUndefined();
+    });
+  });
+
+  describe('consumeLatestUsage', () => {
+    test('returns usage and removes it', () => {
+      const id1 = SSEUsageExtractor.nextRequestId();
+      SSEUsageExtractor.processStreamForUsage(
+        id1,
+        `data: {"usage":{"prompt_tokens":100,"completion_tokens":10,"total_tokens":110}}\n\n`
+      );
+      const latest = SSEUsageExtractor.consumeLatestUsage();
+      expect(latest).toBeDefined();
+      expect(latest!.promptTokens).toBe(100);
+      expect(SSEUsageExtractor.size()).toBe(0);
+    });
+
+    test('returns undefined when no usage stored', () => {
+      expect(SSEUsageExtractor.consumeLatestUsage()).toBeUndefined();
+    });
+  });
+
+  describe('OpenRouter real-world SSE format', () => {
+    test('extracts usage from OpenRouter-style SSE response', () => {
+      const sseData = [
+        'data: {"id":"gen-123","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}',
+        '',
+        'data: {"id":"gen-123","choices":[{"index":0,"delta":{"content":"Hello"},"finish_reason":null}]}',
+        '',
+        'data: {"id":"gen-123","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":15506,"completion_tokens":80,"total_tokens":15586,"prompt_tokens_details":{"cached_tokens":0},"completion_tokens_details":{"reasoning_tokens":0}}}',
+        '',
+        'data: [DONE]',
+        '',
+      ].join('\n');
+
+      const result = SSEUsageExtractor.extractUsageFromSSEChunk(sseData);
+      expect(result).toBeDefined();
+      expect(result!.promptTokens).toBe(15506);
+      expect(result!.completionTokens).toBe(80);
+      expect(result!.totalTokens).toBe(15586);
+      expect(result!.cachedTokens).toBe(0);
+      expect(result!.reasoningTokens).toBe(0);
+    });
+  });
+});

--- a/js/tests/token.test.ts
+++ b/js/tests/token.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, describe } from 'bun:test';
+import { Token } from '../src/util/token';
+
+/**
+ * Tests for Token estimation and counting utilities.
+ *
+ * @see https://github.com/link-assistant/agent/issues/249
+ */
+
+describe('Token.estimate', () => {
+  test('returns 0 for empty string', () => {
+    expect(Token.estimate('')).toBe(0);
+  });
+
+  test('returns 0 for falsy input', () => {
+    // @ts-expect-error testing edge case
+    expect(Token.estimate(null)).toBe(0);
+    // @ts-expect-error testing edge case
+    expect(Token.estimate(undefined)).toBe(0);
+  });
+
+  test('estimates ~4 characters per token', () => {
+    // "hello world" = 11 chars → 11/4 = 2.75 → rounds to 3
+    expect(Token.estimate('hello world')).toBe(3);
+  });
+
+  test('estimates longer text', () => {
+    const text = 'a'.repeat(400);
+    expect(Token.estimate(text)).toBe(100);
+  });
+
+  test('handles 1 character', () => {
+    expect(Token.estimate('a')).toBe(0); // 1/4 = 0.25 → rounds to 0
+  });
+
+  test('handles 2 characters', () => {
+    expect(Token.estimate('ab')).toBe(1); // 2/4 = 0.5 → rounds to 1
+  });
+});
+
+describe('Token.countTokens', () => {
+  test('returns 0 for empty string', () => {
+    const result = Token.countTokens('');
+    expect(result.count).toBe(0);
+    expect(result.precise).toBe(true);
+  });
+
+  test('returns non-zero for real text', () => {
+    const result = Token.countTokens(
+      'Hello, world! This is a test of the tokenizer.'
+    );
+    expect(result.count).toBeGreaterThan(0);
+    // If gpt-tokenizer is available, it should be precise
+    // If not, it falls back to estimate
+    expect(typeof result.precise).toBe('boolean');
+  });
+
+  test('uses BPE tokenizer when available (gpt-tokenizer)', () => {
+    // gpt-tokenizer is installed as a dependency, so this should use real BPE
+    const result = Token.countTokens('Hello world');
+    // With o200k_base, "Hello world" is typically 2 tokens
+    // The precise flag indicates real BPE was used
+    if (result.precise) {
+      // Real BPE: should be a small number of tokens for a short phrase
+      expect(result.count).toBeLessThan(10);
+      expect(result.count).toBeGreaterThan(0);
+    }
+  });
+
+  test('gives reasonable count for larger text', () => {
+    // ~1000 characters of typical English text
+    const text = 'The quick brown fox jumps over the lazy dog. '.repeat(22);
+    const result = Token.countTokens(text);
+    // ~1000 chars should be roughly 200-300 tokens regardless of method
+    expect(result.count).toBeGreaterThan(100);
+    expect(result.count).toBeLessThan(500);
+  });
+
+  test('BPE count differs from heuristic estimate for code', () => {
+    // Code tends to have a different token/char ratio than English prose
+    const code = `function calculateTotal(items: Item[]): number {
+  return items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+}`;
+    const bpeResult = Token.countTokens(code);
+    const heuristicResult = Token.estimate(code);
+
+    // Both should be reasonable, but may differ
+    expect(bpeResult.count).toBeGreaterThan(0);
+    expect(heuristicResult).toBeGreaterThan(0);
+
+    if (bpeResult.precise) {
+      // BPE tokenization typically produces more tokens for code due to
+      // splitting on special characters, while heuristic uses flat 4 chars/token
+      // They should be in the same order of magnitude
+      expect(Math.abs(bpeResult.count - heuristicResult)).toBeLessThan(
+        heuristicResult * 2
+      );
+    }
+  });
+});

--- a/rust/src/cli.rs
+++ b/rust/src/cli.rs
@@ -25,7 +25,9 @@ pub const DEFAULT_COMPACTION_MODELS: &str =
     "(big-pickle minimax-m2.5-free nemotron-3-super-free gpt-5-nano same)";
 
 /// Default compaction safety margin as a percentage of usable context window.
-pub const DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT: u32 = 15;
+/// Increased from 15% to 25% to reduce probability of context overflow errors.
+/// @see https://github.com/link-assistant/agent/issues/249
+pub const DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT: u32 = 25;
 
 /// Agent CLI - A minimal AI CLI agent compatible with OpenCode's JSON interface
 #[derive(Parser, Debug)]

--- a/rust/tests/cli.rs
+++ b/rust/tests/cli.rs
@@ -343,5 +343,5 @@ fn test_default_compaction_models_matches_js() {
 
 #[test]
 fn test_default_compaction_safety_margin_matches_js() {
-    assert_eq!(DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT, 15);
+    assert_eq!(DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT, 25);
 }

--- a/rust/tests/cli_options.rs
+++ b/rust/tests/cli_options.rs
@@ -582,7 +582,7 @@ fn compaction_safety_margin_default() {
         .args(["--dry-run", "--verbose", "-p", "hello"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("Compaction safety margin: 15%"));
+        .stdout(predicate::str::contains("Compaction safety margin: 25%"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Fixes #249 — Context overflow error when AI SDK drops token usage from raw provider response, causing compaction to never trigger.

### Root Cause (verified from raw HTTP logs)

**The provider DOES return valid usage data**, but the AI SDK fails to propagate it:

1. **Raw HTTP response contains valid tokens**: OpenRouter SSE stream includes `"prompt_tokens": 15506, "completion_tokens": 80` in the final chunk
2. **AI SDK `@ai-sdk/openai-compatible` drops usage**: Despite receiving valid usage, the AI SDK's `finish-step` event reports 0 for all token counts. This is a **known upstream bug** (vercel/ai #9921, #12477, #7412)
3. **`max_tokens` not capped to available context**: Always requested 32,000 output tokens even when only 31,999 were available
4. **Safety margin too narrow**: 85% threshold (15% margin) assumed reliable token counts

### Changes

#### Fix 1: Lower safety margin from 85% to 75%
Matches OpenCode upstream; provides larger buffer for inaccurate/missing token counts (Gemini CLI uses 50%, Claude Code uses ~83.5%)

#### Fix 2: Real BPE tokenization via `gpt-tokenizer`
`Token.countTokens()` uses `o200k_base` encoding for accurate token counting on OpenAI-compatible models, with character-based heuristic fallback (~4 chars/token) for models with unavailable tokenizers

#### Fix 3: Cap `maxOutputTokens`
Ensure `estimatedInput + maxOutput` never exceeds model context limit

#### Fix 4: Raw SSE usage recovery (AI SDK bypass) ← NEW
**`SSEUsageExtractor`** intercepts raw HTTP SSE streaming responses at the `fetch()` level and parses usage tokens directly from SSE `data:` chunks. When the AI SDK's `finish-step` event reports zero tokens, the processor automatically recovers usage from the raw SSE data.

- Works in both verbose and non-verbose modes
- Supports OpenAI, Anthropic, Groq, and generic SSE usage formats
- Modeled after OpenAI Codex's approach (raw HTTP + manual SSE parsing)
- Provides Codex-like reliability while keeping the AI SDK abstraction

#### Enhanced diagnostics
Verbose mode logs raw usage vs parsed usage to detect AI SDK propagation failures; zero-token warning now fires regardless of finishReason

### SDK Research: What Other CLIs Use

| Tool | SDK | Usage Source |
|------|-----|-------------|
| **OpenCode** | Vercel AI SDK (`ai` v6) | `streamText` usage — same bug exposure |
| **Codex** | Custom Rust (reqwest + SSE) | Hand-parsed SSE events — most reliable |
| **Gemini CLI** | `@google/genai` v1.30 | `usageMetadata` from SDK |
| **Claude Code** | `@anthropic-ai/sdk` | Messages API usage field |
| **Aider** | `litellm` v1.82 | `completion.usage` via litellm |

The Vercel AI SDK streaming usage bug is a **known open issue** (vercel/ai #9921, #12477). Our SSE usage recovery provides the reliability of Codex's approach while keeping the AI SDK for its provider abstraction.

### Future work: Switchable SDK backends
Full backend alternatives (direct fetch, provider-specific SDKs, LiteLLM) require significant architectural work and are tracked as a separate feature request.

### Files Changed

| File | Change |
|------|--------|
| `js/src/util/sse-usage-extractor.ts` | NEW: Raw SSE stream usage parser (AI SDK bypass) |
| `js/src/provider/provider.ts` | SSE stream interception for usage extraction |
| `js/src/session/processor.ts` | SSE usage recovery + enhanced zero-token diagnostics |
| `js/src/util/token.ts` | `countTokens()` with real BPE via gpt-tokenizer |
| `js/src/session/compaction.ts` | Lower margin 0.85→0.75, estimation fallback |
| `js/src/session/prompt.ts` | `Token.countTokens()` for overflow, cap output tokens |
| `js/src/cli/defaults.ts` | Update default margin 15%→25% |
| `rust/src/cli.rs` | Sync Rust default 15%→25% |
| `js/package.json` | Add `gpt-tokenizer` dependency |
| `js/tests/sse-usage-extractor.test.ts` | 17 tests for SSE usage extraction |
| `js/tests/token.test.ts` | 11 tests for Token.estimate and Token.countTokens |
| `js/tests/compaction-model.test.ts` | Update expectations, add estimation tests |
| `docs/case-studies/issue-249/` | Case study with deep root cause, SDK research |

## Test plan

- [x] All 54 JS tests pass (26 compaction + 11 token + 17 SSE usage extractor)
- [x] All Rust tests pass
- [x] Prettier formatting verified
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)