### PR TITLE
Rename Rust crate to link-assistant-agent and fix CI/CD publishing

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -251,8 +251,18 @@ jobs:
         run: cargo build --release
         working-directory: rust
 
-      - name: Create GitHub Release
+      - name: Publish to crates.io
+        id: publish
         if: steps.check.outputs.should_release == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --verbose
+          echo "published=true" >> $GITHUB_OUTPUT
+        working-directory: rust
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -262,7 +272,7 @@ jobs:
             --prefix "rust-"
 
       - name: Format GitHub release notes
-        if: steps.check.outputs.should_release == 'true'
+        if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/format-github-release.mjs --release-version "${{ steps.current_version.outputs.version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}" --prefix "rust-"
@@ -318,8 +328,18 @@ jobs:
         run: cargo build --release
         working-directory: rust
 
-      - name: Create GitHub Release
+      - name: Publish to crates.io
+        id: publish
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo publish --verbose
+          echo "published=true" >> $GITHUB_OUTPUT
+        working-directory: rust
+
+      - name: Create GitHub Release
+        if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -329,7 +349,7 @@ jobs:
             --prefix "rust-"
 
       - name: Format GitHub release notes
-        if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
+        if: steps.publish.outputs.published == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node scripts/format-github-release.mjs --release-version "${{ steps.version.outputs.new_version }}" --repository "${{ github.repository }}" --commit-sha "${{ github.sha }}" --prefix "rust-"

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-12T12:07:51.890Z for PR creation at branch issue-251-7e9e7b39eeba for issue https://github.com/link-assistant/agent/issues/251

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-12T12:07:51.890Z for PR creation at branch issue-251-7e9e7b39eeba for issue https://github.com/link-assistant/agent/issues/251

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository contains two implementations of the agent:
 | Implementation                 | Status               | Package Manager | Install Command                        |
 | ------------------------------ | -------------------- | --------------- | -------------------------------------- |
 | [JavaScript/Bun](js/README.md) | **Production Ready** | npm             | `bun install -g @link-assistant/agent` |
-| [Rust](rust/README.md)         | Work in Progress     | cargo           | `cargo install agent` (when published) |
+| [Rust](rust/README.md)         | Work in Progress     | cargo           | `cargo install link-assistant-agent`   |
 
 Both implementations aim to be fully compatible with [OpenCode](https://github.com/sst/opencode)'s `run --format json` mode.
 
@@ -61,6 +61,8 @@ See [js/README.md](js/README.md) for full documentation including:
 - JSON output standards (OpenCode and Claude formats)
 
 ### Rust Implementation
+
+[![Crates.io](https://img.shields.io/crates/v/link-assistant-agent.svg)](https://crates.io/crates/link-assistant-agent)
 
 The Rust implementation provides core functionality but is still under active development.
 

--- a/docs/case-studies/issue-251/README.md
+++ b/docs/case-studies/issue-251/README.md
@@ -1,0 +1,103 @@
+# Case Study: Issue #251 - Rust version should be published as link-assistant-agent
+
+## Timeline
+
+1. **Initial state**: Rust crate was named `agent` in `Cargo.toml` (since first Rust implementation)
+2. **Issue #247 / PR #248**: Fixed CI/CD pipeline that was silently skipping all releases (merged as v0.8.0)
+3. **Issue #251 filed**: Identified that the crate name `agent` conflicts with an existing crate on crates.io, CI/CD lacks actual publishing, and GitHub releases are created without actual crates.io publish
+
+## Requirements from Issue
+
+1. **Crate naming**: Rust package must be published as `link-assistant-agent` on crates.io
+2. **License verification**: Ensure actual license matches before publishing
+3. **Badge coverage**: Crates.io badges must be present in all relevant README files and GitHub releases
+4. **False positive releases**: GitHub release must NOT be created before the crate is actually published to crates.io
+5. **Case study**: Document findings in `docs/case-studies/issue-251/`
+
+## Root Causes
+
+### 1. Crate name conflict
+
+- **Problem**: The crate was named `agent` in `Cargo.toml`, but this name is already taken on crates.io by another author (liangshuai, published 2025-11-19, version 0.0.1, "A flexible AI Agent SDK for building intelligent agents")
+- **Root cause**: The crate name was chosen without checking crates.io availability
+- **Impact**: The crate could never be published to crates.io under the name `agent`
+
+### 2. Missing `cargo publish` step in CI/CD
+
+- **Problem**: The Rust release workflow (`rust.yml`) had no `cargo publish` step at all
+- **Root cause**: When the release pipeline was created, the crates.io publish step was never added. The JS pipeline (`js.yml`) correctly publishes to npm before creating a GitHub release, but this pattern was not replicated for Rust
+- **Impact**: GitHub releases were created giving the appearance of a published crate, but the crate was never actually available on crates.io
+
+### 3. False positive GitHub releases
+
+- **Problem**: GitHub releases were created unconditionally (after build success), not gated on successful crates.io publish
+- **Root cause**: The release steps had no dependency on a publish step (which didn't exist)
+- **Impact**: Users seeing GitHub releases would expect the crate to be installable via `cargo install agent`, but it was not available
+- **Comparison**: The JS pipeline correctly gates GitHub release creation on `steps.publish.outputs.published == 'true'`
+
+### 4. Badge pointing to wrong crate
+
+- **Problem**: The crates.io badge in `rust/README.md` pointed to `https://crates.io/crates/agent` (someone else's crate)
+- **Root cause**: Badge was added assuming the crate would be published under the name `agent`
+- **Impact**: Badge would show version information for a completely different crate
+
+## Solutions Implemented
+
+### 1. Renamed crate to `link-assistant-agent`
+
+- Changed `name` in `[package]` section of `Cargo.toml` to `link-assistant-agent`
+- Changed `name` in `[lib]` section to `link_assistant_agent` (Rust convention: underscores in lib names)
+- Kept `[[bin]]` name as `agent` so users still get the `agent` binary when installing
+- Updated all `use agent::` imports to `use link_assistant_agent::` in source and test files
+- Updated integration test helpers to use `Command::cargo_bin("agent")` instead of `cargo_bin_cmd!()` macro (which defaults to package name)
+
+### 2. Added `cargo publish` step to CI/CD
+
+- Added "Publish to crates.io" step in both `auto-release` and `manual-release` jobs
+- Uses `CARGO_REGISTRY_TOKEN` secret for authentication
+- Step outputs `published=true` on success
+
+### 3. Fixed release ordering
+
+- GitHub release creation is now conditional on `steps.publish.outputs.published == 'true'`
+- Release notes formatting is also gated on successful publish
+- This matches the JS pipeline pattern exactly
+
+### 4. Updated all badges and install commands
+
+- `rust/README.md`: Badge now points to `link-assistant-agent` on crates.io
+- `rust/README.md`: Install command updated to `cargo install link-assistant-agent`
+- `README.md` (root): Install command updated in implementations table
+- `README.md` (root): Added crates.io badge under Rust Implementation section
+
+### 5. License verification
+
+- `Cargo.toml` specifies `license = "Unlicense"`
+- Root `LICENSE` file contains the full Unlicense text (public domain dedication)
+- **Verified**: License is consistent and correct
+
+## Required Setup for Repository Owner
+
+Before the next release, the repository owner must:
+
+1. **Create a crates.io API token**: Go to https://crates.io/settings/tokens and create a token with publish scope
+2. **Add `CARGO_REGISTRY_TOKEN` secret**: In GitHub repository settings > Secrets and variables > Actions, add the token as `CARGO_REGISTRY_TOKEN`
+
+## Comparison: JS vs Rust Release Pipeline
+
+| Aspect | JavaScript (js.yml) | Rust (rust.yml) - After Fix |
+|--------|--------------------|-----------------------------|
+| Package registry | npm | crates.io |
+| Publish step | `node scripts/publish-to-npm.mjs` | `cargo publish --verbose` |
+| Auth mechanism | npm OIDC trusted publishing | `CARGO_REGISTRY_TOKEN` secret |
+| Publish before release | Yes | Yes (fixed) |
+| Release gated on publish | Yes (`steps.publish.outputs.published`) | Yes (fixed) |
+| Changelog system | Changesets (`.changeset/`) | Fragments (`changelog.d/`) |
+
+## Verification
+
+- All tests pass after crate rename (`cargo test` - all passing)
+- Formatting check passes (`cargo fmt --check`)
+- Clippy passes (no new warnings introduced)
+- Name `link-assistant-agent` is available on crates.io (verified via API - returns 404)
+- Binary name remains `agent` for user convenience

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,37 +3,6 @@
 version = 4
 
 [[package]]
-name = "agent"
-version = "0.7.0"
-dependencies = [
- "anyhow",
- "assert_cmd",
- "async-trait",
- "base64",
- "chrono",
- "clap",
- "dotenvy",
- "glob",
- "ignore",
- "predicates",
- "rand 0.8.5",
- "regex",
- "reqwest",
- "serde",
- "serde_json",
- "similar",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "ulid",
- "uuid",
- "walkdir",
- "which",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,6 +831,37 @@ name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+
+[[package]]
+name = "link-assistant-agent"
+version = "0.8.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "async-trait",
+ "base64",
+ "chrono",
+ "clap",
+ "dotenvy",
+ "glob",
+ "ignore",
+ "predicates",
+ "rand 0.8.5",
+ "regex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "similar",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "ulid",
+ "uuid",
+ "walkdir",
+ "which",
+]
 
 [[package]]
 name = "linux-raw-sys"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "agent"
+name = "link-assistant-agent"
 version = "0.8.0"
 edition = "2021"
 description = "A minimal, public domain AI CLI agent compatible with OpenCode's JSON interface"
@@ -68,7 +68,7 @@ assert_cmd = "2.0"
 predicates = "3.1"
 
 [lib]
-name = "agent"
+name = "link_assistant_agent"
 path = "src/lib.rs"
 
 [[bin]]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,8 +1,8 @@
-# agent (Rust)
+# link-assistant-agent (Rust)
 
 **A minimal, public domain AI CLI agent compatible with OpenCode's JSON interface**
 
-[![Crates.io](https://img.shields.io/crates/v/agent.svg)](https://crates.io/crates/agent)
+[![Crates.io](https://img.shields.io/crates/v/link-assistant-agent.svg)](https://crates.io/crates/link-assistant-agent)
 [![License: Unlicense](https://img.shields.io/badge/license-Unlicense-blue.svg)](http://unlicense.org/)
 
 > This is the Rust implementation. See also the [JavaScript/Bun implementation](../js/README.md).
@@ -65,10 +65,10 @@ cargo build --release
 ./target/release/agent --help
 ```
 
-### From crates.io (when published)
+### From crates.io
 
 ```bash
-cargo install agent
+cargo install link-assistant-agent
 ```
 
 ## Quick Start

--- a/rust/changelog.d/20260412_000000_rename_crate_and_fix_publishing.md
+++ b/rust/changelog.d/20260412_000000_rename_crate_and_fix_publishing.md
@@ -1,0 +1,17 @@
+---
+bump: minor
+---
+
+### Changed
+
+- Renamed crate from `agent` to `link-assistant-agent` on crates.io to avoid name conflict with existing `agent` crate
+- Binary name remains `agent` for user convenience (`cargo install link-assistant-agent` installs the `agent` binary)
+
+### Fixed
+
+- CI/CD pipeline now publishes to crates.io before creating GitHub releases, preventing false positive releases
+- GitHub release is only created after successful crates.io publish (matching the JS pipeline behavior)
+
+### Added
+
+- Crates.io badge added to root README under Rust Implementation section

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -3,10 +3,10 @@
 //! This is the Rust implementation of the @link-assistant/agent CLI tool.
 //! It provides the same functionality as the JavaScript/Bun version but runs as a native binary.
 
-use agent::cli;
-use agent::error::Result;
 use clap::Parser;
 use cli::Args;
+use link_assistant_agent::cli;
+use link_assistant_agent::error::Result;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 #[tokio::main]

--- a/rust/src/util/filesystem.rs
+++ b/rust/src/util/filesystem.rs
@@ -14,7 +14,7 @@ impl Filesystem {
     ///
     /// # Examples
     /// ```
-    /// use agent::util::Filesystem;
+    /// use link_assistant_agent::util::Filesystem;
     ///
     /// assert!(Filesystem::overlaps("/home/user", "/home/user/docs"));
     /// assert!(Filesystem::overlaps("/home/user/docs", "/home/user"));
@@ -44,7 +44,7 @@ impl Filesystem {
     ///
     /// # Examples
     /// ```
-    /// use agent::util::Filesystem;
+    /// use link_assistant_agent::util::Filesystem;
     ///
     /// assert!(Filesystem::contains("/home/user", "/home/user/docs"));
     /// assert!(!Filesystem::contains("/home/user/docs", "/home/user"));

--- a/rust/tests/cli.rs
+++ b/rust/tests/cli.rs
@@ -2,11 +2,11 @@
 //!
 //! Extracted from the original inline tests in rust/src/cli.rs.
 
-use agent::cli::{
+use clap::Parser;
+use link_assistant_agent::cli::{
     Args, InputMessage, DEFAULT_COMPACTION_MODEL, DEFAULT_COMPACTION_MODELS,
     DEFAULT_COMPACTION_SAFETY_MARGIN_PERCENT, DEFAULT_MODEL,
 };
-use clap::Parser;
 
 #[test]
 fn test_parse_json_input() {

--- a/rust/tests/cli_options.rs
+++ b/rust/tests/cli_options.rs
@@ -4,13 +4,13 @@
 //! as the JavaScript implementation, ensuring full feature parity.
 //! Each option is tested via the compiled binary using assert_cmd.
 
-use assert_cmd::cargo_bin_cmd;
+use assert_cmd::Command;
 use predicates::prelude::*;
 use std::io::Write;
 
 /// Helper to create a Command for the agent binary.
 fn agent_cmd() -> assert_cmd::Command {
-    cargo_bin_cmd!()
+    Command::cargo_bin("agent").unwrap()
 }
 
 // ── Model option ──────────────────────────────────────────────────────

--- a/rust/tests/error.rs
+++ b/rust/tests/error.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from the original inline tests in rust/src/error.rs.
 
-use agent::error::AgentError;
+use link_assistant_agent::error::AgentError;
 
 #[test]
 fn test_file_not_found_error() {

--- a/rust/tests/id.rs
+++ b/rust/tests/id.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from the original inline tests in rust/src/id.rs.
 
-use agent::id::{ascending, descending, Prefix};
+use link_assistant_agent::id::{ascending, descending, Prefix};
 
 #[test]
 fn test_prefix_strings() {

--- a/rust/tests/temperature_option.rs
+++ b/rust/tests/temperature_option.rs
@@ -7,12 +7,12 @@
 //! These tests verify the Rust CLI binary accepts and parses the
 //! --temperature flag correctly, mirroring the JavaScript test suite.
 
-use assert_cmd::cargo_bin_cmd;
+use assert_cmd::Command;
 use predicates::prelude::*;
 
 /// Helper to create a Command for the agent binary.
 fn agent_cmd() -> assert_cmd::Command {
-    cargo_bin_cmd!()
+    Command::cargo_bin("agent").unwrap()
 }
 
 #[test]

--- a/rust/tests/tool_bash.rs
+++ b/rust/tests/tool_bash.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/bash.tools.test.js
 //! and the original inline tests from rust/src/tool/bash.rs.
 
-use agent::tool::bash::BashTool;
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::bash::BashTool;
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use tempfile::TempDir;
 

--- a/rust/tests/tool_batch.rs
+++ b/rust/tests/tool_batch.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/batch.tools.test.js
 //! and the original inline tests from rust/src/tool/batch.rs.
 
-use agent::tool::batch::BatchTool;
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::batch::BatchTool;
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;

--- a/rust/tests/tool_codesearch.rs
+++ b/rust/tests/tool_codesearch.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/codesearch.tools.test.js
 //! and the original inline tests from rust/src/tool/codesearch.rs.
 
-use agent::tool::codesearch::CodeSearchTool;
-use agent::tool::Tool;
+use link_assistant_agent::tool::codesearch::CodeSearchTool;
+use link_assistant_agent::tool::Tool;
 
 #[test]
 fn test_params_schema() {

--- a/rust/tests/tool_context.rs
+++ b/rust/tests/tool_context.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from the original inline tests in rust/src/tool/context.rs.
 
-use agent::tool::ToolContext;
+use link_assistant_agent::tool::ToolContext;
 use std::path::PathBuf;
 
 #[test]

--- a/rust/tests/tool_edit.rs
+++ b/rust/tests/tool_edit.rs
@@ -3,12 +3,12 @@
 //! Mirrors test coverage from js/tests/integration/edit.tools.test.js
 //! and the original inline tests from rust/src/tool/edit.rs.
 
-use agent::tool::edit::{
+use link_assistant_agent::tool::edit::{
     try_context_aware_replace, try_escape_normalized_replace, try_exact_replace,
     try_indentation_flexible_replace, try_multi_occurrence_replace, try_trimmed_boundary_replace,
     EditTool,
 };
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;

--- a/rust/tests/tool_glob.rs
+++ b/rust/tests/tool_glob.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/glob.tools.test.js
 //! and the original inline tests from rust/src/tool/glob.rs.
 
-use agent::tool::glob::GlobTool;
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::glob::GlobTool;
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use std::path::Path;

--- a/rust/tests/tool_grep.rs
+++ b/rust/tests/tool_grep.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/grep.tools.test.js
 //! and the original inline tests from rust/src/tool/grep.rs.
 
-use agent::tool::grep::{matches_glob, GrepTool};
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::grep::{matches_glob, GrepTool};
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use std::path::Path;

--- a/rust/tests/tool_invalid.rs
+++ b/rust/tests/tool_invalid.rs
@@ -3,8 +3,8 @@
 //! Mirrors the original inline tests from rust/src/tool/invalid.rs
 //! and js/src/tool/invalid.ts behavior.
 
-use agent::tool::invalid::InvalidTool;
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::invalid::InvalidTool;
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use tempfile::TempDir;
 

--- a/rust/tests/tool_list.rs
+++ b/rust/tests/tool_list.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/list.tools.test.js
 //! and the original inline tests from rust/src/tool/list.rs.
 
-use agent::tool::list::{should_ignore, ListTool};
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::list::{should_ignore, ListTool};
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use std::path::Path;

--- a/rust/tests/tool_multiedit.rs
+++ b/rust/tests/tool_multiedit.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/src/tool/multiedit.ts behavior
 //! and the original inline tests from rust/src/tool/multiedit.rs.
 
-use agent::tool::multiedit::MultiEditTool;
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::multiedit::MultiEditTool;
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;

--- a/rust/tests/tool_read.rs
+++ b/rust/tests/tool_read.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/read.tools.test.js
 //! and the original inline tests from rust/src/tool/read.rs.
 
-use agent::tool::read::ReadTool;
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::read::ReadTool;
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use std::path::Path;

--- a/rust/tests/tool_registry.rs
+++ b/rust/tests/tool_registry.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from the original inline tests in rust/src/tool/mod.rs.
 
-use agent::tool::ToolRegistry;
+use link_assistant_agent::tool::ToolRegistry;
 
 #[test]
 fn test_registry_creation() {

--- a/rust/tests/tool_todo.rs
+++ b/rust/tests/tool_todo.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/todo.tools.test.js
 //! and the original inline tests from rust/src/tool/todo.rs.
 
-use agent::tool::todo::{TodoReadTool, TodoWriteTool};
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::todo::{TodoReadTool, TodoWriteTool};
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use tempfile::TempDir;
 

--- a/rust/tests/tool_webfetch.rs
+++ b/rust/tests/tool_webfetch.rs
@@ -3,7 +3,9 @@
 //! Mirrors test coverage from js/tests/integration/webfetch.tools.test.js
 //! and the original inline tests from rust/src/tool/webfetch.rs.
 
-use agent::tool::webfetch::{decode_html_entities, extract_text_from_html, strip_remaining_tags};
+use link_assistant_agent::tool::webfetch::{
+    decode_html_entities, extract_text_from_html, strip_remaining_tags,
+};
 
 #[test]
 fn test_extract_text_from_html() {
@@ -69,8 +71,8 @@ fn test_extract_text_from_plain() {
     assert!(text.contains("Just plain text"));
 }
 
-use agent::tool::webfetch::WebFetchTool;
-use agent::tool::Tool;
+use link_assistant_agent::tool::webfetch::WebFetchTool;
+use link_assistant_agent::tool::Tool;
 
 #[test]
 fn test_webfetch_tool_id() {

--- a/rust/tests/tool_websearch.rs
+++ b/rust/tests/tool_websearch.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/websearch.tools.test.js
 //! and the original inline tests from rust/src/tool/websearch.rs.
 
-use agent::tool::websearch::WebSearchTool;
-use agent::tool::Tool;
+use link_assistant_agent::tool::websearch::WebSearchTool;
+use link_assistant_agent::tool::Tool;
 
 #[test]
 fn test_params_schema() {

--- a/rust/tests/tool_write.rs
+++ b/rust/tests/tool_write.rs
@@ -3,8 +3,8 @@
 //! Mirrors test coverage from js/tests/integration/write.tools.test.js
 //! and the original inline tests from rust/src/tool/write.rs.
 
-use agent::tool::write::WriteTool;
-use agent::tool::{Tool, ToolContext};
+use link_assistant_agent::tool::write::WriteTool;
+use link_assistant_agent::tool::{Tool, ToolContext};
 use serde_json::json;
 use std::fs;
 use tempfile::TempDir;

--- a/rust/tests/util_binary.rs
+++ b/rust/tests/util_binary.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from the original inline tests in rust/src/util/binary.rs.
 
-use agent::util::binary::{
+use link_assistant_agent::util::binary::{
     is_binary_extension, is_binary_file, is_image_extension, validate_image_format,
 };
 use std::path::PathBuf;

--- a/rust/tests/util_filesystem.rs
+++ b/rust/tests/util_filesystem.rs
@@ -2,7 +2,7 @@
 //!
 //! Extracted from the original inline tests in rust/src/util/filesystem.rs.
 
-use agent::util::filesystem::Filesystem;
+use link_assistant_agent::util::filesystem::Filesystem;
 
 #[test]
 fn test_relative_path() {


### PR DESCRIPTION
## Summary

- **Renamed** Rust crate from `agent` to `link-assistant-agent` — the name `agent` is already taken on crates.io (owned by a different author, published 2025-11-19)
- **Fixed** CI/CD false positive: GitHub releases were created without actually publishing to crates.io. Now `cargo publish` runs first, and GitHub release is only created on success
- **Updated** all badges, install commands, and imports across the codebase

## Changes

### Crate Rename
- `Cargo.toml`: package name → `link-assistant-agent`, lib name → `link_assistant_agent`
- Binary name stays `agent` (users run `cargo install link-assistant-agent` and get the `agent` command)
- All `use agent::` imports updated to `use link_assistant_agent::` in source and 21 test files
- Integration test helpers updated to use explicit binary name lookup

### CI/CD Publishing Fix
- Added "Publish to crates.io" step in both `auto-release` and `manual-release` jobs in `rust.yml`
- GitHub release creation is now gated on `steps.publish.outputs.published == 'true'` (matching the JS pipeline pattern)
- Uses `CARGO_REGISTRY_TOKEN` secret for crates.io authentication

### Documentation
- Updated crates.io badges in `rust/README.md` and root `README.md`
- Updated install commands from `cargo install agent` to `cargo install link-assistant-agent`
- Added case study in `docs/case-studies/issue-251/`
- Added changelog fragment

### License Verification
- `Cargo.toml` specifies `Unlicense` — matches the root `LICENSE` file (public domain dedication) ✓

## Required Setup
Before the next Rust release, the repository owner must add `CARGO_REGISTRY_TOKEN` as a GitHub Actions secret (create token at https://crates.io/settings/tokens with publish scope).

## Test plan

- [x] `cargo check` passes
- [x] `cargo test` — all tests pass
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` — no new warnings
- [x] Verified `link-assistant-agent` is available on crates.io (API returns 404)
- [x] Verified `agent` crate on crates.io belongs to different author
- [ ] CI pipeline passes on this PR

Fixes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)