### PR TITLE
fix(ci): use CARGO_TOKEN as fallback for CARGO_REGISTRY_TOKEN in Rust CI/CD

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -255,7 +255,7 @@ jobs:
         id: publish
         if: steps.check.outputs.should_release == 'true'
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: node scripts/publish-to-crates.mjs --should-pull
 
       - name: Create GitHub Release
@@ -329,7 +329,7 @@ jobs:
         id: publish
         if: steps.version.outputs.version_committed == 'true' || steps.version.outputs.already_released == 'true'
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
         run: node scripts/publish-to-crates.mjs
 
       - name: Create GitHub Release

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-13T06:27:15.964Z for PR creation at branch issue-257-664495cf8b36 for issue https://github.com/link-assistant/agent/issues/257

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-13T06:27:15.964Z for PR creation at branch issue-257-664495cf8b36 for issue https://github.com/link-assistant/agent/issues/257

--- a/docs/case-studies/issue-257/README.md
+++ b/docs/case-studies/issue-257/README.md
@@ -1,0 +1,90 @@
+# Case Study: CARGO_REGISTRY_TOKEN Not Set — Use CARGO_TOKEN as Fallback (Issue #257)
+
+## Summary
+
+The Rust CI/CD publish step fails because `CARGO_REGISTRY_TOKEN` secret is not configured at the repository level. The organization has `CARGO_TOKEN` set at the organization level, which should be used as a fallback.
+
+## Timeline
+
+| Time (UTC) | Event | Run ID | Details |
+|---|---|---|---|
+| 2026-04-12 12:49 | Push to main | 24307135603 | Auto Release failed — `Cargo.lock` uncommitted (separate issue, fixed in #255) |
+| 2026-04-13 01:55 | Push to main | 24322104554 | Auto Release skipped — `rust-v0.9.0` tag already exists, no new fragments |
+| 2026-04-13 06:19 | Push to main (merge #256) | 24328743522 | Auto Release failed — `CARGO_REGISTRY_TOKEN` is empty |
+
+## Root Cause
+
+### `CARGO_REGISTRY_TOKEN` secret is not set at the repository level
+
+The workflow passes `secrets.CARGO_REGISTRY_TOKEN` to the publish step:
+
+```yaml
+- name: Publish to crates.io
+  env:
+    CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  run: node scripts/publish-to-crates.mjs --should-pull
+```
+
+The CI logs confirm the token is empty:
+
+```
+Auto Release  Publish to crates.io  env:
+Auto Release  Publish to crates.io    CARGO_REGISTRY_TOKEN: 
+```
+
+The publish script (`scripts/publish-to-crates.mjs`) detects this and exits:
+
+```
+Error: CARGO_REGISTRY_TOKEN environment variable is not set
+##[error]Process completed with exit code 1.
+```
+
+The organization has a `CARGO_TOKEN` secret set at the organization level that can be used as a fallback.
+
+### Why `CARGO_REGISTRY_TOKEN` is the expected variable name
+
+Cargo natively reads `CARGO_REGISTRY_TOKEN` to authenticate with crates.io. The `cargo publish` command uses this environment variable automatically. However, organizations may use different naming conventions for their secrets (e.g., `CARGO_TOKEN`). The fix needs to bridge this gap.
+
+## Affected Components
+
+1. **`.github/workflows/rust.yml`** — Both `auto-release` and `manual-release` jobs pass `CARGO_REGISTRY_TOKEN` to the publish step
+2. **`scripts/publish-to-crates.mjs`** — Checks only `CARGO_REGISTRY_TOKEN` environment variable
+
+## Solution
+
+### Fix 1: Workflow — Use `CARGO_TOKEN` as fallback in env
+
+In both `auto-release` and `manual-release` jobs, set `CARGO_REGISTRY_TOKEN` from `CARGO_TOKEN` when `CARGO_REGISTRY_TOKEN` is not available:
+
+```yaml
+env:
+  CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}
+```
+
+This uses GitHub Actions' expression fallback: if `CARGO_REGISTRY_TOKEN` is empty/unset, it falls back to `CARGO_TOKEN`.
+
+### Fix 2: Script — Add fallback logic in publish script
+
+The `publish-to-crates.mjs` script should also resolve the token with fallback, so it works correctly regardless of how it's invoked:
+
+```javascript
+const token = process.env.CARGO_REGISTRY_TOKEN || process.env.CARGO_TOKEN;
+if (!token) {
+  console.error('Error: Neither CARGO_REGISTRY_TOKEN nor CARGO_TOKEN environment variable is set');
+  process.exit(1);
+}
+process.env.CARGO_REGISTRY_TOKEN = token;
+```
+
+## Verification
+
+After the fix, the publish step should:
+1. Resolve the token from either `CARGO_REGISTRY_TOKEN` or `CARGO_TOKEN`
+2. Set `CARGO_REGISTRY_TOKEN` so `cargo publish` can use it natively
+3. Log which source the token came from (without revealing the token value)
+
+## Lessons Learned
+
+1. **Use fallback secrets for organization-level tokens**: When a secret may be set at different levels (repo vs org), use the `||` operator in GitHub Actions expressions to provide fallback.
+2. **Script-level fallback is defense-in-depth**: Even though the workflow sets the env var, the script should also handle fallback to be robust when run locally or from other contexts.
+3. **Log token source, not value**: When debugging auth issues, knowing *which* secret was used helps without exposing credentials.

--- a/docs/case-studies/issue-257/ci-log-excerpts.md
+++ b/docs/case-studies/issue-257/ci-log-excerpts.md
@@ -1,0 +1,59 @@
+# CI Log Excerpts for Issue #257
+
+## Run 24328743522 (2026-04-13, commit 33d1d8c — merge of PR #256)
+
+### Job summary
+
+| Job | Conclusion |
+|---|---|
+| Lint and Format Check | success |
+| Test (ubuntu-latest) | success |
+| Test (macos-latest) | success |
+| Build Package | success |
+| **Auto Release** | **failure** |
+| Manual Release | skipped |
+
+### Auto Release: Publish to crates.io step
+
+```
+##[group]Run node scripts/publish-to-crates.mjs --should-pull
+node scripts/publish-to-crates.mjs --should-pull
+shell: /usr/bin/bash -e {0}
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_HOME: /home/runner/.cargo
+  CARGO_INCREMENTAL: 0
+  CARGO_REGISTRY_TOKEN:                          ← EMPTY: secret not set
+##[endgroup]
+Detected multi-language repository (Cargo.toml in rust/)
+Pulling latest changes...
+From https://github.com/link-assistant/agent
+ * branch            main       -> FETCH_HEAD
+   243c7ae..de0c003  main       -> origin/main
+Updating 243c7ae..de0c003
+Fast-forward
+ js/.changeset/fix-rust-publish-verification.md | 5 -----
+ js/CHANGELOG.md                                | 6 ++++++
+ js/package-lock.json                           | 4 ++--
+ js/package.json                                | 2 +-
+ 4 files changed, 9 insertions(+), 8 deletions(-)
+ delete mode 100644 js/.changeset/fix-rust-publish-verification.md
+Publishing link-assistant-agent@0.9.1 to crates.io...
+Checking if link-assistant-agent@0.9.1 is already on crates.io...
+Error: CARGO_REGISTRY_TOKEN environment variable is not set
+Crate link-assistant-agent does not exist on crates.io yet (first publish)
+##[error]Process completed with exit code 1.
+```
+
+## Run 24307135603 (2026-04-12, commit 62978b1 — different failure)
+
+This earlier run also had `CARGO_REGISTRY_TOKEN` empty but failed earlier due to uncommitted `Cargo.lock` changes (fixed in PR #255 by adding `--allow-dirty`):
+
+```
+Auto Release  Publish to crates.io  env:
+Auto Release  Publish to crates.io    CARGO_REGISTRY_TOKEN:    ← also empty
+Auto Release  Publish to crates.io  error: 1 files in the working directory contain changes
+                                     that were not yet committed into git:
+                                     Cargo.lock
+Auto Release  Publish to crates.io  ##[error]Process completed with exit code 101.
+```

--- a/js/.changeset/cargo-token-fallback.md
+++ b/js/.changeset/cargo-token-fallback.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/agent': patch
+---
+
+Add CARGO_TOKEN fallback support to publish-to-crates.mjs for organization-level secrets

--- a/rust/changelog.d/20260413_cargo_token_fallback.md
+++ b/rust/changelog.d/20260413_cargo_token_fallback.md
@@ -1,0 +1,7 @@
+---
+bump: patch
+---
+
+### Fixed
+
+- Use `CARGO_TOKEN` (organization-level secret) as fallback when `CARGO_REGISTRY_TOKEN` is not set, fixing crates.io publishing in CI/CD

--- a/scripts/publish-to-crates.mjs
+++ b/scripts/publish-to-crates.mjs
@@ -11,8 +11,9 @@
  * - Verifies the crate actually appeared on crates.io after publishing
  * - Outputs `published=true` and `published_version=X.Y.Z` for GitHub Actions
  *
- * Required environment variables:
+ * Required environment variables (at least one must be set):
  * - CARGO_REGISTRY_TOKEN: API token for crates.io
+ * - CARGO_TOKEN: Fallback API token (e.g. set at organization level)
  *
  * Optional environment variables:
  * - GITHUB_OUTPUT: GitHub Actions output file path
@@ -199,10 +200,17 @@ async function main() {
       );
     }
 
-    // Verify CARGO_REGISTRY_TOKEN is set
+    // Resolve CARGO_REGISTRY_TOKEN with CARGO_TOKEN as fallback
+    if (!process.env.CARGO_REGISTRY_TOKEN && process.env.CARGO_TOKEN) {
+      console.log(
+        'CARGO_REGISTRY_TOKEN not set, using CARGO_TOKEN as fallback'
+      );
+      process.env.CARGO_REGISTRY_TOKEN = process.env.CARGO_TOKEN;
+    }
+
     if (!process.env.CARGO_REGISTRY_TOKEN) {
       console.error(
-        'Error: CARGO_REGISTRY_TOKEN environment variable is not set'
+        'Error: Neither CARGO_REGISTRY_TOKEN nor CARGO_TOKEN environment variable is set'
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

Fixes #257

The Rust CI/CD Auto Release job fails at the "Publish to crates.io" step because `CARGO_REGISTRY_TOKEN` secret is not configured at the repository level. The organization has `CARGO_TOKEN` set at the organization level.

**Root cause**: CI logs from run [24328743522](https://github.com/link-assistant/agent/actions/runs/24328743522) confirm `CARGO_REGISTRY_TOKEN` is empty:
```
CARGO_REGISTRY_TOKEN: 
...
Error: CARGO_REGISTRY_TOKEN environment variable is not set
```

## Changes

- **`.github/workflows/rust.yml`**: Use `secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN` fallback in both `auto-release` and `manual-release` jobs
- **`scripts/publish-to-crates.mjs`**: Add runtime fallback from `CARGO_TOKEN` to `CARGO_REGISTRY_TOKEN` with clear logging of which source is used
- **`rust/changelog.d/`**: Add changelog fragment for the fix
- **`docs/case-studies/issue-257/`**: Full case study with timeline, root cause analysis, and CI log excerpts

## How it works

1. **Workflow level** (primary): GitHub Actions `${{ secrets.CARGO_REGISTRY_TOKEN || secrets.CARGO_TOKEN }}` resolves to whichever secret is available
2. **Script level** (defense-in-depth): If `CARGO_REGISTRY_TOKEN` is empty but `CARGO_TOKEN` is set, the script copies it over and logs the fallback

## Test plan

- [ ] Verify CI passes on this PR (lint, test, build — no publish attempt on PR)
- [ ] After merge, verify Auto Release job succeeds with the token fallback
- [ ] Confirm crate is published to crates.io after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)