### PR TITLE
Fix stream-json tool use details

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-27T03:36:32.513Z for PR creation at branch issue-281-8d4563b818c2 for issue https://github.com/link-assistant/agent/issues/281

--- a/js/.changeset/fix-stream-json-tool-use.md
+++ b/js/.changeset/fix-stream-json-tool-use.md
@@ -1,0 +1,5 @@
+---
+'@link-assistant/agent': patch
+---
+
+Report tool names and inputs correctly in `stream-json` tool-use events.

--- a/js/src/json-standard/index.ts
+++ b/js/src/json-standard/index.ts
@@ -111,13 +111,12 @@ export function convertOpenCodeToClaude(
     case 'tool_use':
       if (event.part && event.part.state) {
         const state = event.part.state as Record<string, unknown>;
-        const tool = state.tool as Record<string, unknown> | undefined;
         return {
           type: 'tool_use',
           timestamp,
           session_id,
-          name: (tool?.name as string) || 'unknown',
-          input: tool?.parameters || {},
+          name: (event.part.tool as string) || 'unknown',
+          input: state.input || {},
           tool_use_id: event.part.id as string,
         };
       }

--- a/js/tests/json-standard-unit.js
+++ b/js/tests/json-standard-unit.js
@@ -121,11 +121,13 @@ describe('JSON Standard Module - Unit Tests', () => {
         sessionID: 'ses_test123',
         part: {
           id: 'prt_tool123',
+          type: 'tool',
+          callID: 'call_tool123',
+          tool: 'write',
           state: {
-            tool: {
-              name: 'bash',
-              parameters: { command: 'ls' },
-            },
+            status: 'pending',
+            input: { filePath: 'hi.txt', content: 'hi\n' },
+            raw: '',
           },
         },
       };
@@ -134,8 +136,11 @@ describe('JSON Standard Module - Unit Tests', () => {
 
       expect(claudeEvent).not.toBeNull();
       expect(claudeEvent.type).toBe('tool_use');
-      expect(claudeEvent.name).toBe('bash');
-      expect(claudeEvent.input).toEqual({ command: 'ls' });
+      expect(claudeEvent.name).toBe('write');
+      expect(claudeEvent.input).toEqual({
+        filePath: 'hi.txt',
+        content: 'hi\n',
+      });
       expect(claudeEvent.tool_use_id).toBe('prt_tool123');
     });
 


### PR DESCRIPTION
Fixes #281

## Summary

- Read tool names from the runtime tool part's `tool` field.
- Read tool arguments from the tool state's `input` field.
- Replace the obsolete synthetic unit fixture with a schema-accurate `write` tool event.
- Add a patch changeset for the JavaScript package.

## Reproduction and coverage

The regression fixture mirrors the real `MessageV2.ToolPart` emitted for a streamed tool call:

```js
{
  type: 'tool',
  tool: 'write',
  state: {
    status: 'pending',
    input: { filePath: 'hi.txt', content: 'hi\n' },
  },
}
```

Before the fix, the converter produced `name: "unknown"` and `input: {}` because it looked for the obsolete `state.tool.name` and `state.tool.parameters` fields. The updated test asserts the emitted event contains `name: "write"` and the original input.

## Verification

```bash
cd js
bun test ./tests/json-standard-unit.js
npm run check
npm test
```

Observed locally: focused converter tests passed (18/18), repository checks passed, and the full JavaScript suite passed with 609 pass / 4 todo / 0 fail.
