### PR TITLE
fix(json): include human-readable message in error events

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-07-30T18:32:11.164Z for PR creation at branch issue-285-531ca23a5284 for issue https://github.com/link-assistant/agent/issues/285
 # Updated: 2026-07-31T18:24:47.217Z
+# Updated: 2026-08-05T10:14:30.852Z

--- a/docs/stdin-mode.md
+++ b/docs/stdin-mode.md
@@ -440,6 +440,28 @@ Claude `stream-json` output:
 Drivers can flush queued `user_prompt` frames after this event instead of
 interrupting an in-progress turn.
 
+### Error Events
+
+Every emitted `error` event carries a human-readable `message` string next to
+the machine-readable `error` payload, so consumers never have to re-derive the
+text (and never publish `[object Object]`):
+
+```json
+{
+  "type": "error",
+  "timestamp": 1718630400000,
+  "sessionID": "ses_abc123",
+  "message": "RetryTimeoutExceededError: Retry timeout exceeded after 604800s",
+  "error": {
+    "name": "RetryTimeoutExceededError",
+    "data": { "message": "Retry timeout exceeded after 604800s" }
+  }
+}
+```
+
+The `error` field is unchanged — `message` is purely additive. Consumers should
+prefer `record.message` and fall back to rendering `record.error` themselves.
+
 ## Status Messages
 
 When entering listening mode, the CLI outputs a JSON status message (pretty-printed by default).

--- a/js/.changeset/nervous-poems-repeat.md
+++ b/js/.changeset/nervous-poems-repeat.md
@@ -1,0 +1,8 @@
+---
+'@link-assistant/agent': patch
+---
+
+JSON `error` events now always carry a human-readable `message` string next to
+the machine-readable `error` object (#289). Consumers that interpolated
+`record.error` previously published `[object Object]` and lost the real failure
+cause. The change is additive: the `error` field is unchanged.

--- a/js/src/cli/cmd/run.ts
+++ b/js/src/cli/cmd/run.ts
@@ -264,7 +264,11 @@ export const RunCommand = cmd({
               err = String(props.error.data.message);
             }
             errorMsg = errorMsg ? errorMsg + EOL + err : err;
-            if (outputJsonEvent('error', { error: props.error })) continue;
+            // Always include the human-readable string alongside the
+            // machine-readable object so consumers never print
+            // "[object Object]" (#289).
+            if (outputJsonEvent('error', { message: err, error: props.error }))
+              continue;
             UI.error(err);
           }
 

--- a/js/src/cli/continuous-mode.js
+++ b/js/src/cli/continuous-mode.js
@@ -11,6 +11,7 @@ import { SessionPrompt } from '../session/prompt.ts';
 import { createEventHandler, serializeOutput } from '../json-standard/index.ts';
 import { createContinuousStdinReader } from './input-queue.js';
 import { outputBusEvent } from './event-handler.js';
+import { errorText } from '../util/error-text.ts';
 import { Permission } from '../permission/index.ts';
 import { Log } from '../util/log.ts';
 import { config } from '../config/config.ts';
@@ -385,6 +386,7 @@ export async function runContinuousServerMode(
           type: 'error',
           timestamp: Date.now(),
           sessionID,
+          message: errorText(error),
           error: error instanceof Error ? error.message : String(error),
         });
       });
@@ -598,6 +600,7 @@ export async function runContinuousDirectMode(
           type: 'error',
           timestamp: Date.now(),
           sessionID,
+          message: errorText(error),
           error: error instanceof Error ? error.message : String(error),
         });
       });

--- a/js/src/cli/event-handler.js
+++ b/js/src/cli/event-handler.js
@@ -4,6 +4,7 @@
  */
 
 import { Bus } from '../bus/index.ts';
+import { errorText } from '../util/error-text.ts';
 
 /**
  * Create a subscription for session bus events that outputs events in the selected JSON format.
@@ -90,11 +91,13 @@ export function outputBusEvent({
 
       // If tool failed, also output an error event
       if (part.state?.status === 'error') {
+        const stateError = part.state.error;
         eventHandler.output({
           type: 'error',
           timestamp: Date.now(),
           sessionID,
-          error: part.state.error || 'Tool execution failed',
+          message: errorText(stateError, 'Tool execution failed'),
+          error: stateError || 'Tool execution failed',
         });
       }
     }
@@ -145,6 +148,7 @@ export function outputBusEvent({
       type: 'error',
       timestamp: Date.now(),
       sessionID,
+      message: errorText(props.error),
       error: props.error,
     });
   }

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -27,6 +27,7 @@ import { McpCommand } from './cli/cmd/mcp.ts';
 import { AuthCommand } from './cli/cmd/auth.ts';
 import { FormatError } from './cli/error.ts';
 import { UI } from './cli/ui.ts';
+import { errorText } from './util/error-text.ts';
 import {
   createVerboseFetch,
   registerPendingStreamLogExitHandler,
@@ -520,6 +521,7 @@ async function runServerMode(
         type: 'error',
         timestamp: Date.now(),
         sessionID,
+        message: errorText(error),
         error: error instanceof Error ? error.message : String(error),
       });
     });
@@ -605,6 +607,7 @@ async function runDirectMode(
         type: 'error',
         timestamp: Date.now(),
         sessionID,
+        message: errorText(error),
         error: error instanceof Error ? error.message : String(error),
       });
     });

--- a/js/src/util/error-text.ts
+++ b/js/src/util/error-text.ts
@@ -1,0 +1,82 @@
+/**
+ * Human-readable rendering of arbitrary error values (issue #289).
+ *
+ * JSON `error` events used to carry only the machine-readable
+ * `NamedError.toObject()` shape (`{name, data: {message}}`), so consumers doing
+ * `` `${record.error}` `` published `[object Object]` and the real cause was
+ * lost. Every emitted `error` event now also carries a `message` string
+ * produced by `stringifyErrorValue`.
+ *
+ * The renderer is circular-safe and depth-limited, and never invents a
+ * placeholder: when nothing readable can be derived it returns an empty
+ * string so the caller can pick its own fallback.
+ */
+
+const MAX_DEPTH = 5;
+
+function fromParts(name: string | undefined, message: string | undefined) {
+  if (name && message) return `${name}: ${message}`;
+  return message || name || '';
+}
+
+function render(value: unknown, depth: number, seen: Set<object>): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'number' || typeof value === 'boolean')
+    return String(value);
+  if (typeof value !== 'object') return '';
+
+  const object = value as Record<string, unknown>;
+  if (seen.has(object)) return '';
+  if (depth >= MAX_DEPTH) return '';
+  seen.add(object);
+
+  if (Array.isArray(object)) {
+    const rendered = object
+      .map((item) => render(item, depth + 1, seen))
+      .filter((item) => item.length > 0);
+    return rendered.join('; ');
+  }
+
+  if (object instanceof Error) {
+    return fromParts(object.name, object.message) || String(object);
+  }
+
+  // NamedError.toObject(): { name, data: { message, ... } }
+  const name = typeof object.name === 'string' ? object.name : undefined;
+  const data = object.data;
+  if (data && typeof data === 'object') {
+    const dataMessage = render(
+      (data as Record<string, unknown>).message,
+      depth + 1,
+      seen
+    );
+    if (dataMessage) return fromParts(name, dataMessage);
+  }
+
+  const message = render(object.message, depth + 1, seen);
+  if (message) return fromParts(name, message);
+
+  // Envelope shapes: { error: … }, { cause: … }
+  const nested =
+    render(object.error, depth + 1, seen) ||
+    render(object.cause, depth + 1, seen);
+  if (nested) return name ? fromParts(name, nested) : nested;
+
+  return name || '';
+}
+
+/**
+ * Render any error-ish value as a human-readable string.
+ * Returns an empty string when nothing readable can be derived.
+ */
+export function stringifyErrorValue(value: unknown): string {
+  return render(value, 0, new Set<object>());
+}
+
+/**
+ * Same as {@link stringifyErrorValue} but guarantees a non-empty string.
+ */
+export function errorText(value: unknown, fallback = 'Unknown error'): string {
+  return stringifyErrorValue(value) || fallback;
+}

--- a/js/tests/error-text.ts
+++ b/js/tests/error-text.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from 'bun:test';
+import { errorText, stringifyErrorValue } from '../src/util/error-text.ts';
+
+describe('stringifyErrorValue', () => {
+  test('renders NamedError.toObject() shape (issue #289)', () => {
+    expect(
+      stringifyErrorValue({
+        name: 'RetryTimeoutExceededError',
+        data: { message: 'Retry timeout exceeded after 604800s' },
+      })
+    ).toBe('RetryTimeoutExceededError: Retry timeout exceeded after 604800s');
+  });
+
+  test('renders plain strings unchanged', () => {
+    expect(stringifyErrorValue('boom')).toBe('boom');
+  });
+
+  test('renders Error instances', () => {
+    expect(stringifyErrorValue(new TypeError('bad input'))).toBe(
+      'TypeError: bad input'
+    );
+  });
+
+  test('unwraps nested { error: … } envelopes', () => {
+    expect(
+      stringifyErrorValue({ error: { name: 'InnerError', data: {} } })
+    ).toBe('InnerError');
+  });
+
+  test('joins arrays of errors', () => {
+    expect(stringifyErrorValue([new Error('a'), 'b'])).toBe('Error: a; b');
+  });
+
+  test('falls back to the name when no message exists', () => {
+    expect(stringifyErrorValue({ name: 'SomeError' })).toBe('SomeError');
+  });
+
+  test('is circular-safe', () => {
+    const value: Record<string, unknown> = { name: 'Cyclic' };
+    value.error = value;
+    expect(stringifyErrorValue(value)).toBe('Cyclic');
+  });
+
+  test('is depth-limited', () => {
+    let value: Record<string, unknown> = { message: 'deep' };
+    for (let i = 0; i < 20; i++) value = { error: value };
+    expect(() => stringifyErrorValue(value)).not.toThrow();
+  });
+
+  test('returns an empty string when nothing is readable', () => {
+    expect(stringifyErrorValue({})).toBe('');
+    expect(stringifyErrorValue(null)).toBe('');
+  });
+});
+
+describe('errorText', () => {
+  test('uses the fallback only when nothing is readable', () => {
+    expect(errorText({}, 'Tool execution failed')).toBe(
+      'Tool execution failed'
+    );
+    expect(errorText({ message: 'real' }, 'Tool execution failed')).toBe(
+      'real'
+    );
+  });
+
+  test('never returns "[object Object]"', () => {
+    expect(errorText({ name: 'E', data: { message: 'm' } })).toBe('E: m');
+  });
+});

--- a/js/tests/event-handler.js
+++ b/js/tests/event-handler.js
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { createBusEventSubscription } from '../src/cli/event-handler.js';
+import {
+  createBusEventSubscription,
+  outputBusEvent,
+} from '../src/cli/event-handler.js';
 import { Bus } from '../src/bus/index.ts';
 import { Instance } from '../src/project/instance.ts';
 import { SessionStatus } from '../src/session/status.ts';
@@ -37,5 +40,90 @@ describe('createBusEventSubscription', () => {
         );
       },
     });
+  });
+});
+
+describe('outputBusEvent error events (issue #289)', () => {
+  test('session.error carries a human-readable message alongside the object', () => {
+    const outputs = [];
+    outputBusEvent({
+      event: {
+        type: 'session.error',
+        properties: {
+          sessionID: 'ses_err',
+          error: {
+            name: 'RetryTimeoutExceededError',
+            data: { message: 'Retry timeout exceeded after 604800s' },
+          },
+        },
+      },
+      sessionID: 'ses_err',
+      eventHandler: {
+        output(event) {
+          outputs.push(event);
+        },
+      },
+      onError() {},
+    });
+
+    const error = outputs.find((event) => event.type === 'error');
+    expect(error.message).toBe(
+      'RetryTimeoutExceededError: Retry timeout exceeded after 604800s'
+    );
+    // The machine-readable object is still emitted (additive change).
+    expect(error.error.name).toBe('RetryTimeoutExceededError');
+    expect(`${error.message}`).not.toBe('[object Object]');
+  });
+
+  test('failed tool parts carry a human-readable message', () => {
+    const outputs = [];
+    outputBusEvent({
+      event: {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            sessionID: 'ses_tool',
+            type: 'tool',
+            state: { status: 'error', error: { name: 'ToolError' } },
+          },
+        },
+      },
+      sessionID: 'ses_tool',
+      eventHandler: {
+        output(event) {
+          outputs.push(event);
+        },
+      },
+      onError() {},
+    });
+
+    const error = outputs.find((event) => event.type === 'error');
+    expect(error.message).toBe('ToolError');
+  });
+
+  test('failed tool parts without any error detail use the fallback', () => {
+    const outputs = [];
+    outputBusEvent({
+      event: {
+        type: 'message.part.updated',
+        properties: {
+          part: {
+            sessionID: 'ses_tool2',
+            type: 'tool',
+            state: { status: 'error' },
+          },
+        },
+      },
+      sessionID: 'ses_tool2',
+      eventHandler: {
+        output(event) {
+          outputs.push(event);
+        },
+      },
+      onError() {},
+    });
+
+    const error = outputs.find((event) => event.type === 'error');
+    expect(error.message).toBe('Tool execution failed');
   });
 });


### PR DESCRIPTION
## Summary

Fixes #289.

JSON `error` events carried only the machine-readable `NamedError.toObject()`
payload, so any consumer doing `` `${record.error}` `` published
`[object Object]` and the real failure cause was lost (as happened in
link-assistant/hive-mind#2141).

Every emitted `error` event now also carries a human-readable `message` string.
The change is **additive** — the `error` field is untouched, so existing
consumers keep working.

## Changes

- **New** `js/src/util/error-text.ts` — `stringifyErrorValue()` / `errorText()`:
  renders `{name, data:{message}}`, `Error` instances, nested `{error:…}` /
  `{cause:…}` envelopes, arrays and strings. Circular-safe, depth-limited, and
  it never invents a placeholder (`stringifyErrorValue` returns `''` when
  nothing is readable; `errorText` applies an explicit fallback).
- `js/src/cli/cmd/run.ts` — the `--output-format json` path now emits the `err`
  string it already computed: `outputJsonEvent('error', { message: err, error: props.error })`.
- `js/src/cli/event-handler.js` — both the `session.error` event and failed tool
  parts now emit `message` (tool failures fall back to `Tool execution failed`).
- `js/src/index.js`, `js/src/cli/continuous-mode.js` — prompt-rejection error
  events also carry `message`.
- `docs/stdin-mode.md` — documents the error-event shape.
- Changeset added (patch).

## Wire format

```json
{
  "type": "error",
  "timestamp": 1718630400000,
  "sessionID": "ses_abc123",
  "message": "RetryTimeoutExceededError: Retry timeout exceeded after 604800s",
  "error": {
    "name": "RetryTimeoutExceededError",
    "data": { "message": "Retry timeout exceeded after 604800s" }
  }
}
```

## Reproduction & tests

Before the fix, `console.log(\`${record.message || record.error}\`)` on a
`session.error` record printed `Agent reported error: [object Object]`.

- `js/tests/error-text.ts` — unit tests for the renderer (NamedError shape,
  `Error`, arrays, nested envelopes, circular refs, depth limit, fallbacks).
- `js/tests/event-handler.js` — new `outputBusEvent` tests asserting the
  `message` field on `session.error` and on failed tool parts, including an
  explicit `not.toBe('[object Object]')` assertion.

Full suite: `694 pass, 0 fail`. `npm run check` (eslint + prettier + file-size)
passes.
